### PR TITLE
Migrate PyPI URLs to `files.pythonhosted.org`

### DIFF
--- a/conda_forge_tick/migrators/pip_wheel_dep.py
+++ b/conda_forge_tick/migrators/pip_wheel_dep.py
@@ -60,7 +60,7 @@ class PipWheelMigrator(MiniMigrator):
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         run_reqs = attrs.get("requirements", {}).get("run", set())
         source_url: str = attrs.get("url") or attrs.get("source", {}).get("url")  # type: ignore[assignment] # TODO: this assumes source.url exists
-        url_names = ["pypi.python.org", "pypi.org", "pypi.io"]
+        url_names = ["pypi.python.org", "pypi.org", "pypi.io", "files.pythonhosted.org"]
         if not any(s in source_url for s in url_names):
             return True
         if not get_keys_default(

--- a/conda_forge_tick/migrators/pypi_org.py
+++ b/conda_forge_tick/migrators/pypi_org.py
@@ -5,16 +5,18 @@ from conda_forge_tick.migrators.core import MiniMigrator, skip_migrator_due_to_s
 from conda_forge_tick.migrators.libboost import _replacer
 
 # detect "url: https://pypi.io/packages/..."
-raw_pat_pypi_io = r"^(?P<before>[\s\-]*url: )(?:https?://pypi\.io/)(?P<after>.*)"
-pat_pypi_io = re.compile(raw_pat_pypi_io)
+raw_pat_legacy_pypi = (
+    r"^(?P<before>[\s\-]*url: )(?:https?://pypi\.(?:io|org)/packages/)(?P<after>.*)"
+)
+pat_legacy_pypi = re.compile(raw_pat_legacy_pypi)
 
 
 class PyPIOrgMigrator(MiniMigrator):
     def filter(self, attrs, not_bad_str_start=""):
         lines = attrs["raw_meta_yaml"].splitlines()
-        has_pypi_io = any(pat_pypi_io.search(line) for line in lines)
+        has_legacy_pypi = any(pat_legacy_pypi.search(line) for line in lines)
         # filter() returns True if we _don't_ want to migrate
-        return (not has_pypi_io) or skip_migrator_due_to_schema(
+        return (not has_legacy_pypi) or skip_migrator_due_to_schema(
             attrs, self.allowed_schema_versions
         )
 
@@ -25,7 +27,9 @@ class PyPIOrgMigrator(MiniMigrator):
                 lines = fp.readlines()
 
             lines = _replacer(
-                lines, raw_pat_pypi_io, r"\g<before>https://pypi.org/\g<after>"
+                lines,
+                raw_pat_legacy_pypi,
+                r"\g<before>https://files.pythonhosted.org/packages/\g<after>",
             )
 
             with open(fname, "w") as fp:

--- a/conda_forge_tick/pypi_name_mapping.py
+++ b/conda_forge_tick/pypi_name_mapping.py
@@ -69,6 +69,7 @@ def extract_pypi_name_from_metadata_source_url(
                     url.startswith("https://pypi.io/packages/")
                     or url.startswith("https://pypi.org/packages/")
                     or url.startswith("https://pypi.python.org/packages/")
+                    or url.startswith("https://files.pythonhosted.org/packages/")
                 ):
                     return canonicalize_pypi_name(url.split("/")[-2])
     return None

--- a/tests/test_pypi_org.py
+++ b/tests/test_pypi_org.py
@@ -22,6 +22,7 @@ VERSION_WITH_PYPI_ORG = Version(
     "feedstock,new_ver",
     [
         ("seaborn", "0.13.2"),
+        ("seaborn_org", "0.13.2"),
     ],
 )
 def test_pypi_org(feedstock, new_ver, tmp_path):

--- a/tests/test_yaml/pypi_org_seaborn_after_meta.yaml
+++ b/tests/test_yaml/pypi_org_seaborn_after_meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/s/seaborn/seaborn-{{ version }}.tar.gz
+  url: https://files.pythonhosted.org/packages/source/s/seaborn/seaborn-{{ version }}.tar.gz
   sha256: 93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7
 
 build:

--- a/tests/test_yaml/pypi_org_seaborn_org_after_meta.yaml
+++ b/tests/test_yaml/pypi_org_seaborn_org_after_meta.yaml
@@ -1,0 +1,74 @@
+{% set version = "0.13.2" %}
+{% set build = 0 %}
+
+package:
+  name: seaborn-split
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/source/s/seaborn/seaborn-{{ version }}.tar.gz
+  sha256: 93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7
+
+build:
+  number: {{ build }}
+  noarch: python
+
+test:
+  imports:
+    - seaborn
+  requires:
+    - pip
+  commands:
+    - pip check
+
+outputs:
+  - name: seaborn-base
+    build:
+      noarch: python
+    script: build_base.bat  # [win]
+    script: build_base.sh  # [not win]
+    requirements:
+      host:
+        - python >=3.8
+        - pip
+        - flit-core >=3.2,<4
+      run:
+        - python >=3.8
+        - numpy >=1.20,!=1.24.0
+        - matplotlib-base >=3.4,!=3.6.1
+        - scipy >=1.7
+        - pandas >=1.2
+      run_constrained:
+        # should be {{ pin_subpackage("seaborn", exact=True) }}
+        # but this seems to be broken right now: https://github.com/conda/conda-build/issues/4415
+        - seaborn ={{ version }}=*_{{ build }}
+      test:
+        imports:
+          - seaborn
+
+  - name: seaborn
+    build:
+      noarch: python
+    requirements:
+      run:
+        - statsmodels >=0.12
+        - {{ pin_subpackage('seaborn-base', exact=True) }}
+
+about:
+  home: https://seaborn.pydata.org
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.md
+  summary: Statistical data visualization
+  description: |
+    Seaborn is a Python visualization library based on matplotlib. It
+    provides a high-level interface for drawing attractive statistical graphics.
+  doc_url: https://seaborn.pydata.org
+  dev_url: https://github.com/mwaskom/seaborn
+
+extra:
+  feedstock-name: seaborn
+  recipe-maintainers:
+    - msarahan
+    - r-jain1
+    - croth1

--- a/tests/test_yaml/pypi_org_seaborn_org_before_meta.yaml
+++ b/tests/test_yaml/pypi_org_seaborn_org_before_meta.yaml
@@ -1,0 +1,74 @@
+{% set version = "0.13.1" %}
+{% set build = 2 %}
+
+package:
+  name: seaborn-split
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/seaborn/seaborn-{{ version }}.tar.gz
+  sha256: bfad65e9c5989e5e1897e61bdbd2f22e62455940ca76fd49eca3ed69345b9179
+
+build:
+  number: {{ build }}
+  noarch: python
+
+test:
+  imports:
+    - seaborn
+  requires:
+    - pip
+  commands:
+    - pip check
+
+outputs:
+  - name: seaborn-base
+    build:
+      noarch: python
+    script: build_base.bat  # [win]
+    script: build_base.sh  # [not win]
+    requirements:
+      host:
+        - python >=3.8
+        - pip
+        - flit-core >=3.2,<4
+      run:
+        - python >=3.8
+        - numpy >=1.20,!=1.24.0
+        - matplotlib-base >=3.4,!=3.6.1
+        - scipy >=1.7
+        - pandas >=1.2
+      run_constrained:
+        # should be {{ pin_subpackage("seaborn", exact=True) }}
+        # but this seems to be broken right now: https://github.com/conda/conda-build/issues/4415
+        - seaborn ={{ version }}=*_{{ build }}
+      test:
+        imports:
+          - seaborn
+
+  - name: seaborn
+    build:
+      noarch: python
+    requirements:
+      run:
+        - statsmodels >=0.12
+        - {{ pin_subpackage('seaborn-base', exact=True) }}
+
+about:
+  home: https://seaborn.pydata.org
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.md
+  summary: Statistical data visualization
+  description: |
+    Seaborn is a Python visualization library based on matplotlib. It
+    provides a high-level interface for drawing attractive statistical graphics.
+  doc_url: https://seaborn.pydata.org
+  dev_url: https://github.com/mwaskom/seaborn
+
+extra:
+  feedstock-name: seaborn
+  recipe-maintainers:
+    - msarahan
+    - r-jain1
+    - croth1


### PR DESCRIPTION
#### Description:

Update the PyPI URL migrator to use `files.pythonhosted.org` rather than `pypi.org`, as the former is the canonical URL per upstream documentation: https://docs.pypi.org/api/#predictable-urls

Extend it to migrate `pypi.org` URLs as well. While at it, update a few old migrators to support `files.pythonhosted.org` in addition to the other domains.

#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

xref https://github.com/conda-forge/conda-forge.github.io/issues/2878
