### PR TITLE
Add R feedstock v0 -> v1 recipe migration: `GenericV0ToV1Migrator` + `RV0ToV1Migrator`

### DIFF
--- a/conda_forge_tick/make_migrators.py
+++ b/conda_forge_tick/make_migrators.py
@@ -65,6 +65,7 @@ from conda_forge_tick.migrators import (
     PyPIOrgMigrator,
     Replacement,
     RUCRTCleanup,
+    RV0ToV1Migrator,
     StaticLibMigrator,
     StdlibMigrator,
     UpdateCMakeArgsMigrator,
@@ -111,6 +112,7 @@ DEFAULT_MINI_MIGRATORS = [
     MPIPinRunAsBuildCleanup,
     PyPIOrgMigrator,
     CombineV1ConditionsMigrator,
+    RV0ToV1Migrator,
 ]
 
 

--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -48,3 +48,4 @@ from .noarch_python_min import NoarchPythonMinMigrator
 from .nvtools import AddNVIDIATools
 from .round_trip import YAMLRoundTrip
 from .staticlib import StaticLibMigrator
+from .v0_to_v1 import GenericV0ToV1Migrator

--- a/conda_forge_tick/migrators/__init__.py
+++ b/conda_forge_tick/migrators/__init__.py
@@ -39,6 +39,7 @@ from .pip_check import PipCheckMigrator
 from .pip_wheel_dep import PipWheelMigrator
 from .pypi_org import PyPIOrgMigrator
 from .r_ucrt import RUCRTCleanup
+from .r_v0_to_v1 import RV0ToV1Migrator
 from .cdt import CDTMigrator
 from .recipe_v1 import CombineV1ConditionsMigrator
 from .replacement import Replacement, MiniReplacement

--- a/conda_forge_tick/migrators/r_v0_to_v1.py
+++ b/conda_forge_tick/migrators/r_v0_to_v1.py
@@ -1,0 +1,41 @@
+import typing
+
+from conda_forge_tick.migrators.v0_to_v1 import GenericV0ToV1Migrator
+
+if typing.TYPE_CHECKING:
+    from ..migrators_types import AttrsTypedDict
+
+
+def _is_r_feedstock(attrs: "AttrsTypedDict") -> bool:
+    return (
+        attrs.get("feedstock_name", "").startswith("r-")
+        or attrs.get("name", "").startswith("r-")
+    ) and (
+        "r-base" in attrs.get("raw_meta_yaml", "")
+        or "r-base" in attrs.get("requirements", {}).get("run", set())
+    )
+
+
+class RV0ToV1Migrator(GenericV0ToV1Migrator):
+    """R-specific v0 -> v1 recipe migrator.
+
+    R recipes near-universally template their compiler and Windows/ucrt
+    cross-compilation requirements with ``{{ compiler(...) }}`` and the
+    ``native``/``posix``/``m2w64`` substitution variables. crm already
+    converts these to correct v1 ``if``/``then`` selector syntax; it just
+    can't upgrade the (non-existent) version constraint on a templated
+    dependency, and warns about that on every single one. Ignoring that
+    warning here is safe: there was no version constraint on these
+    dependencies in the v0 recipe for crm to preserve in the first place,
+    so the produced recipe.yaml is unaffected.
+    """
+
+    IGNORED_WARNINGS = GenericV0ToV1Migrator.IGNORED_WARNINGS + (
+        "Recipe upgrades cannot currently upgrade ambiguous version "
+        "constraints on dependencies that use variables:",
+    )
+
+    def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
+        if super().filter(attrs, not_bad_str_start):
+            return True
+        return not _is_r_feedstock(attrs)

--- a/conda_forge_tick/migrators/r_v0_to_v1.py
+++ b/conda_forge_tick/migrators/r_v0_to_v1.py
@@ -53,6 +53,25 @@ class RV0ToV1Migrator(GenericV0ToV1Migrator):
             return self._SPDX_OVERRIDES[lic]
         return super()._to_spdx(lic)
 
+    def _build_script_review_reasons(self, build_sh: str) -> list[str]:
+        # In real feedstocks carrying this pattern (e.g. r-pca3d, r-msqc),
+        # this install_name_tool fix is nested inside `if target_platform ==
+        # osx-64` - but only reachable from the branch that already excludes
+        # osx-64 (the one osx-arm64 falls into), making it dead code that
+        # predates osx-arm64 support entirely.
+        if (
+            "install_name_tool -change" in build_sh
+            and "R.framework/Versions" in build_sh
+        ):
+            return [
+                "build.sh's `install_name_tool` dylib-path fixes for osx-64 are "
+                "commonly nested inside the branch that already excludes "
+                "osx-64 (the one osx-arm64 falls into) - making them dead code "
+                "that's likely never run. Verify whether that's the case here, "
+                "and if so, whether osx-arm64 needs the missing fix."
+            ]
+        return []
+
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         if super().filter(attrs, not_bad_str_start):
             return True

--- a/conda_forge_tick/migrators/r_v0_to_v1.py
+++ b/conda_forge_tick/migrators/r_v0_to_v1.py
@@ -7,6 +7,10 @@ if typing.TYPE_CHECKING:
 
 
 def _is_r_feedstock(attrs: "AttrsTypedDict") -> bool:
+    # R feedstocks are all maintained by the same conda-forge/r team, e.g.
+    # https://github.com/conda-forge/r-essentials-feedstock/blob/main/recipe/meta.yaml#L69-L71
+    if "conda-forge/r" in attrs.get("extra", {}).get("recipe-maintainers", []):
+        return True
     return (
         attrs.get("feedstock_name", "").startswith("r-")
         or attrs.get("name", "").startswith("r-")

--- a/conda_forge_tick/migrators/r_v0_to_v1.py
+++ b/conda_forge_tick/migrators/r_v0_to_v1.py
@@ -39,6 +39,20 @@ class RV0ToV1Migrator(GenericV0ToV1Migrator):
         "constraints on dependencies that use variables:",
     )
 
+    # R-specific SPDX corrections, layered on top of the shared
+    # migrators/license.py mapping via _to_spdx() below - kept here, not in
+    # that shared table, since this is a CRAN-specific convention.
+    _SPDX_OVERRIDES: dict[str, str] = {
+        # CRAN's "Unlimited" license, commonly pre-wrapped as the SPDX
+        # custom-license reference "LicenseRef-Unlimited".
+        "LicenseRef-Unlimited": "Unlimited",
+    }
+
+    def _to_spdx(self, lic: str) -> str:
+        if lic in self._SPDX_OVERRIDES:
+            return self._SPDX_OVERRIDES[lic]
+        return super()._to_spdx(lic)
+
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
         if super().filter(attrs, not_bad_str_start):
             return True

--- a/conda_forge_tick/migrators/v0_to_v1.py
+++ b/conda_forge_tick/migrators/v0_to_v1.py
@@ -39,6 +39,80 @@ _QUOTED_STRING_RE = re.compile(r"(['\"])((?:(?!\1).)*)\1")
 _JINJA_TOKEN_RE = re.compile(r"\$\{\{|\}\}")
 _V0_SELECTOR_RE = re.compile(r"#\s*\[")
 
+# A block-mapping `key: "..."` (or `key: '...'`) whose value opens a quote -
+# see _join_folded_quoted_scalars.
+_SCALAR_KEY_RE = re.compile(r"^([ \t]*[\w.-]+:[ \t]*)([\"'])")
+
+
+def _find_scalar_close(text: str, quote: str) -> int:
+    r"""Given a quote character, find where it closes in
+    ``text`` (-1 if it doesn't), respecting ``\"``
+    and ``''`` escapes.
+    """
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if quote == '"' and ch == "\\":
+            i += 2
+            continue
+        if ch == quote:
+            if quote == "'" and i + 1 < n and text[i + 1] == "'":
+                i += 2
+                continue
+            return i + 1
+        i += 1
+    return -1
+
+
+def _join_folded_quoted_scalars(raw_meta_yaml: str) -> str:
+    """Join a quoted scalar value that YAML folds across multiple physical
+    lines back onto a single line.
+
+    YAML folds a line break inside a quoted scalar into a single space, so
+    this is a semantic no-op - but crm's recipe reader parses selectors line
+    by line, and a continuation line shaped like ``'word' more: words``
+    (quote-led, with a colon later in the line) gets misread as its own
+    key/value pair instead of plain scalar content, crashing with a raw
+    ``ParsingException`` instead of a clean warning (real example:
+    r-stringi's ``about/summary``, a long description wrapped across two
+    lines). Physically joining the fold before crm ever sees it removes the
+    ambiguous line shape entirely.
+    """
+    lines = raw_meta_yaml.split("\n")
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        match = _SCALAR_KEY_RE.match(line)
+        if not match:
+            out.append(line)
+            i += 1
+            continue
+        quote = match.group(2)
+        if _find_scalar_close(line[match.end() :], quote) != -1:
+            out.append(line)
+            i += 1
+            continue
+
+        chunk = [line]
+        j = i + 1
+        closed = False
+        while j < len(lines):
+            chunk.append(lines[j])
+            closed = _find_scalar_close(lines[j].strip(), quote) != -1
+            j += 1
+            if closed:
+                break
+        if not closed:
+            # Genuinely unclosed/malformed - leave as-is and let crm raise
+            # its own error rather than silently swallowing lines.
+            out.append(line)
+            i += 1
+            continue
+        out.append(chunk[0] + "".join(" " + c.strip() for c in chunk[1:]))
+        i = j
+    return "\n".join(out)
+
 
 def _normalize_legacy_license(raw_meta_yaml: str, to_spdx) -> str:
     """Rewrite a recognized legacy license string to its SPDX identifier.
@@ -224,10 +298,11 @@ class GenericV0ToV1Migrator(MiniMigrator):
         not safe to ship unattended, along with the list of messages that
         explain why (empty if the conversion is clean).
         """
-        # Fix legacy license strings crm's own matcher won't recognize, and
-        # hide `environ["X"]` calls before crm's duplicate-key merge can
-        # mangle them - see the two functions' docstrings above.
+        # Join folded multi-line quoted scalars before crm's line-based reader can misparse a continuation line.
+        raw_meta_yaml = _join_folded_quoted_scalars(raw_meta_yaml)
+        # Fix legacy license strings crm's own matcher won't recognize.
         raw_meta_yaml = _normalize_legacy_license(raw_meta_yaml, self._to_spdx)
+        # Hide `environ["X"]` calls before crm's duplicate-key merge can mangle them.
         raw_meta_yaml = _hide_environ_calls(raw_meta_yaml)
 
         # Mirrors what the `crm convert` CLI always does otherwise (e.g.

--- a/conda_forge_tick/migrators/v0_to_v1.py
+++ b/conda_forge_tick/migrators/v0_to_v1.py
@@ -1,0 +1,86 @@
+import logging
+import typing
+from pathlib import Path
+from typing import Any
+
+from conda_recipe_manager.parser._message_table import MessageCategory, MessageTable
+from conda_recipe_manager.parser.exceptions import BaseParserException
+from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConvert
+
+from conda_forge_tick.migrators.core import MiniMigrator
+
+if typing.TYPE_CHECKING:
+    from ..migrators_types import AttrsTypedDict
+
+logger = logging.getLogger(__name__)
+
+
+class GenericV0ToV1Migrator(MiniMigrator):
+    """Convert a schema v0 ``meta.yaml`` recipe to a schema v1 ``recipe.yaml``.
+
+    This only knows about the ``conda-recipe-manager`` (``crm``) conversion
+    mechanics: it converts the recipe and skips (with a warning, leaving the
+    recipe untouched) any conversion that comes back with actionable
+    messages rather than shipping something broken. Subclasses layer
+    package-specific pre/post-processing - and extend ``IGNORED_WARNINGS`` -
+    on top of this class; nothing package-specific lives here.
+    """
+
+    allowed_schema_versions = [0]
+
+    # Warnings that are safe to ignore: crm emits them but the produced
+    # recipe.yaml is already correct. Extend in subclasses, don't rewrite the
+    # safe-to-auto-convert check itself.
+    IGNORED_WARNINGS: tuple[str, ...] = (
+        # crm already removes the deprecated field, the warning is just noise.
+        "Field at `/about/license_family` is no longer supported.",
+    )
+
+    def _actionable_messages(self, msg_tbl: MessageTable) -> list[str]:
+        blocking = list(msg_tbl.get_messages(MessageCategory.EXCEPTION))
+        blocking += msg_tbl.get_messages(MessageCategory.ERROR)
+        blocking += [
+            msg
+            for msg in msg_tbl.get_messages(MessageCategory.WARNING)
+            if not any(ignore in msg for ignore in self.IGNORED_WARNINGS)
+        ]
+        return blocking
+
+    def _convert(self, raw_meta_yaml: str) -> tuple[str | None, list[str]]:
+        """Attempt to convert ``raw_meta_yaml`` (schema v0) to a v1 recipe.
+
+        Returns the converted recipe text, or ``None`` if the conversion is
+        not safe to ship unattended, along with the list of messages that
+        explain why (empty if the conversion is clean).
+        """
+        # crm can *raise* on malformed recipes (ParsingException,
+        # DuplicateKeyException, ...) at construction, before any msg_tbl
+        # exists to record the failure.
+        try:
+            converter = RecipeParserConvert(raw_meta_yaml)
+            v1_content, msg_tbl, _debug = converter.render_to_v1_recipe_format()
+        except BaseParserException as exc:
+            return None, [f"crm raised {type(exc).__name__}: {exc}"]
+
+        blocking = self._actionable_messages(msg_tbl)
+        if blocking:
+            return None, blocking
+        return v1_content, []
+
+    def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
+        meta_yaml_path = Path(recipe_dir) / "meta.yaml"
+        if not meta_yaml_path.exists():
+            return
+
+        v1_content, blocking = self._convert(meta_yaml_path.read_text())
+        if blocking:
+            logger.warning(
+                "Skipping v0 -> v1 conversion for %s: not safe to auto-convert:\n%s",
+                attrs.get("name", recipe_dir),
+                "\n".join(blocking),
+            )
+            return
+
+        assert v1_content is not None
+        (Path(recipe_dir) / "recipe.yaml").write_text(v1_content)
+        meta_yaml_path.unlink()

--- a/conda_forge_tick/migrators/v0_to_v1.py
+++ b/conda_forge_tick/migrators/v0_to_v1.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import typing
 from pathlib import Path
 from typing import Any
@@ -8,11 +9,99 @@ from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConver
 from conda_recipe_manager.parser.types import RecipeReaderFlags
 
 from conda_forge_tick.migrators.core import MiniMigrator
+from conda_forge_tick.migrators.license import _to_spdx
 
 if typing.TYPE_CHECKING:
     from ..migrators_types import AttrsTypedDict
 
 logger = logging.getLogger(__name__)
+
+# Matches a top-level `license:` field's raw value (not `license_family:`/
+# `license_file:` - the colon must follow "license" immediately).
+_LICENSE_LINE_RE = re.compile(
+    r"(?m)^(?P<prefix>[ \t]*license:[ \t]*)(?P<value>.+?)[ \t]*$"
+)
+
+# `{{ environ["FOO"] }}` (common in R/Bioconda `license_file` fields) and a
+# placeholder standing in for it while crm runs - see _hide_environ_calls.
+_ENVIRON_RE = re.compile(r"""\{\{\s*environ\[['"](\w+)['"]\]\s*\}\}""")
+_ENVIRON_PLACEHOLDER_FMT = "__CFTICK_ENVIRON_{}__"
+_ENVIRON_PLACEHOLDER_RE = re.compile(r"__CFTICK_ENVIRON_(\w+)__")
+
+
+def _normalize_legacy_license(raw_meta_yaml: str) -> str:
+    """Rewrite a recognized legacy license string to its SPDX identifier.
+
+    crm has its own SPDX-correction pass, but it only catches a handful of
+    common mistakes and doesn't call out to a real SPDX database (see its
+    ``_fix_bad_licenses``). This repo's own ``LicenseMigrator`` already has a
+    broader, battle-tested mapping (e.g. ``GPL (>= 2)`` -> ``GPL-2.0-or-later``)
+    that crm's matcher doesn't know about; apply it first so crm never has a
+    reason to warn "Could not patch unrecognized license" for a string we
+    already know how to fix.
+    """
+
+    def _repl(match: re.Match) -> str:
+        value = match.group("value")
+        quote = ""
+        unquoted = value
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+            quote = value[0]
+            unquoted = value[1:-1]
+        corrected = _to_spdx(unquoted)
+        if corrected == unquoted:
+            return match.group(0)
+        return f"{match.group('prefix')}{quote}{corrected}{quote}"
+
+    return _LICENSE_LINE_RE.sub(_repl, raw_meta_yaml)
+
+
+def _hide_environ_calls(raw_meta_yaml: str) -> str:
+    """Replace ``{{ environ["X"] }}`` with an inert placeholder before crm
+    sees it.
+
+    crm's own conversion of ``environ["X"]`` -> ``env.get("X")`` is correct
+    for a single occurrence, but when a key is duplicated per-selector (e.g.
+    ``license_file: ...  # [unix]`` / ``# [win]``) and both values contain
+    their own templated expression, crm's duplicate-key ternary merge
+    produces malformed, unparsable output (mismatched ``${{``/``}}``) with
+    no warning at all - the base class's safe-to-auto-convert check has no
+    way to catch it. Hiding the call behind a plain-text placeholder makes
+    crm treat it as an ordinary string for the merge, which it already
+    handles correctly; ``_restore_environ_calls`` puts the real call back
+    afterward.
+    """
+    return _ENVIRON_RE.sub(
+        lambda m: _ENVIRON_PLACEHOLDER_FMT.format(m.group(1)), raw_meta_yaml
+    )
+
+
+def _restore_environ_calls(v1_content: str) -> str:
+    """Undo ``_hide_environ_calls`` in crm's v1 output."""
+
+    def _in_string(match: re.Match) -> str:
+        quote, before, var, after = match.groups()
+        parts = []
+        if before:
+            parts.append(f"{quote}{before}{quote}")
+        parts.append(f'env.get("{var}")')
+        if after:
+            parts.append(f"{quote}{after}{quote}")
+        return "(" + " ~ ".join(parts) + ")"
+
+    # A placeholder embedded inside a quoted string literal - the merged-
+    # ternary case - needs the literal split into a concatenation at the
+    # placeholder's position.
+    content = re.sub(
+        r"(['\"])([^'\"]*)" + _ENVIRON_PLACEHOLDER_RE.pattern + r"([^'\"]*)\1",
+        _in_string,
+        v1_content,
+    )
+    # A placeholder on its own (the common, non-duplicated case) is just the
+    # template call.
+    return _ENVIRON_PLACEHOLDER_RE.sub(
+        lambda m: f'${{{{ env.get("{m.group(1)}") }}}}', content
+    )
 
 
 class GenericV0ToV1Migrator(MiniMigrator):
@@ -58,11 +147,16 @@ class GenericV0ToV1Migrator(MiniMigrator):
         not safe to ship unattended, along with the list of messages that
         explain why (empty if the conversion is clean).
         """
-        # Mirrors what the `crm convert` CLI always does: pre-process the raw
-        # text (e.g. rewrites `{{ environ["FOO"] }}`, common in Bioconda/R
-        # recipes' `license_file`, to valid v1 syntax) and allow the ordinary
-        # `key: val  # [selector]` duplicate-key pattern that's otherwise
-        # extremely common in conda-forge recipes.
+        # Fix legacy license strings crm's own matcher won't recognize, and
+        # hide `environ["X"]` calls before crm's duplicate-key merge can
+        # mangle them - see the two functions' docstrings above.
+        raw_meta_yaml = _normalize_legacy_license(raw_meta_yaml)
+        raw_meta_yaml = _hide_environ_calls(raw_meta_yaml)
+
+        # Mirrors what the `crm convert` CLI always does otherwise (e.g.
+        # normalizing multiline strings, `min_pin`/`max_pin` renames) and
+        # allows the ordinary `key: val  # [selector]` duplicate-key pattern
+        # that's otherwise extremely common in conda-forge recipes.
         content = RecipeParserConvert.pre_process_recipe_text(raw_meta_yaml)
 
         # crm can raise - or, on some malformed/unusual recipes (e.g.
@@ -78,6 +172,7 @@ class GenericV0ToV1Migrator(MiniMigrator):
             logger.debug("CRM failed to convert", exc_info=exc)
             return None, [f"crm raised {type(exc).__name__}: {exc}"]
 
+        v1_content = _restore_environ_calls(v1_content)
         blocking = self._actionable_messages(msg_tbl)
         if blocking:
             return None, blocking

--- a/conda_forge_tick/migrators/v0_to_v1.py
+++ b/conda_forge_tick/migrators/v0_to_v1.py
@@ -34,6 +34,11 @@ class GenericV0ToV1Migrator(MiniMigrator):
     IGNORED_WARNINGS: tuple[str, ...] = (
         # crm already removes the deprecated field, the warning is just noise.
         "Field at `/about/license_family` is no longer supported.",
+        # crm already patched `license` to a corrected SPDX identifier (e.g.
+        # `GPL-2` -> `GPL-2.0-only`, matching this repo's own LicenseMigrator
+        # mapping in migrators/license.py) before emitting this - it's just
+        # noting the change, not something that needs manual review.
+        "license from `",
     )
 
     def _actionable_messages(self, msg_tbl: MessageTable) -> list[str]:

--- a/conda_forge_tick/migrators/v0_to_v1.py
+++ b/conda_forge_tick/migrators/v0_to_v1.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from conda_recipe_manager.parser._message_table import MessageCategory, MessageTable
 from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConvert
+from conda_recipe_manager.parser.recipe_reader import RecipeReader
 from conda_recipe_manager.parser.types import RecipeReaderFlags
 
 from conda_forge_tick.migrators.core import MiniMigrator
@@ -27,6 +28,16 @@ _LICENSE_LINE_RE = re.compile(
 _ENVIRON_RE = re.compile(r"""\{\{\s*environ\[['"](\w+)['"]\]\s*\}\}""")
 _ENVIRON_PLACEHOLDER_FMT = "__CFTICK_ENVIRON_{}__"
 _ENVIRON_PLACEHOLDER_RE = re.compile(r"__CFTICK_ENVIRON_(\w+)__")
+# A single-or-double-quoted string literal, captured whole so a literal
+# containing more than one placeholder (see _restore_environ_calls) can be
+# split at every occurrence, not just the first.
+_QUOTED_STRING_RE = re.compile(r"(['\"])((?:(?!\1).)*)\1")
+
+# Tokens used by _malformed_output_reasons to sanity-check crm's (or our
+# own text-level fixes) v1 output structurally, since crm's message table
+# can report nothing at all for malformed text - see that function.
+_JINJA_TOKEN_RE = re.compile(r"\$\{\{|\}\}")
+_V0_SELECTOR_RE = re.compile(r"#\s*\[")
 
 
 def _normalize_legacy_license(raw_meta_yaml: str) -> str:
@@ -80,28 +91,83 @@ def _restore_environ_calls(v1_content: str) -> str:
     """Undo ``_hide_environ_calls`` in crm's v1 output."""
 
     def _in_string(match: re.Match) -> str:
-        quote, before, var, after = match.groups()
+        quote, body = match.group(1), match.group(2)
+        if not _ENVIRON_PLACEHOLDER_RE.search(body):
+            return match.group(0)
+
+        # A value can have more than one `environ[...]` call in it.
+        # Split at every placeholder, not just the first - otherwise
+        # the second one is left behind as plain text, and the fallback
+        # pass further down wraps it in its own `${{ ... }}`.
         parts = []
-        if before:
-            parts.append(f"{quote}{before}{quote}")
-        parts.append(f'env.get("{var}")')
-        if after:
-            parts.append(f"{quote}{after}{quote}")
+        pos = 0
+        for m in _ENVIRON_PLACEHOLDER_RE.finditer(body):
+            if m.start() > pos:
+                parts.append(f"{quote}{body[pos : m.start()]}{quote}")
+            parts.append(f'env.get("{m.group(1)}")')
+            pos = m.end()
+        if pos < len(body):
+            parts.append(f"{quote}{body[pos:]}{quote}")
         return "(" + " ~ ".join(parts) + ")"
 
     # A placeholder embedded inside a quoted string literal - the merged-
     # ternary case - needs the literal split into a concatenation at the
-    # placeholder's position.
-    content = re.sub(
-        r"(['\"])([^'\"]*)" + _ENVIRON_PLACEHOLDER_RE.pattern + r"([^'\"]*)\1",
-        _in_string,
-        v1_content,
-    )
+    # placeholder's position(s).
+    content = _QUOTED_STRING_RE.sub(_in_string, v1_content)
     # A placeholder on its own (the common, non-duplicated case) is just the
     # template call.
     return _ENVIRON_PLACEHOLDER_RE.sub(
         lambda m: f'${{{{ env.get("{m.group(1)}") }}}}', content
     )
+
+
+def _malformed_output_reasons(v1_content: str) -> list[str]:
+    """Find structural problems in crm's v1 output that its message table
+    can miss entirely.
+
+    crm or our own text-level fixes above can produce malformed v1 text
+    with an empty message table: mismatched ``${{``/``}}``, or a duplicate
+    key left over from a failed selector merge. That output may still be
+    valid YAML in every such case seen so far, so a plain YAML parse isn't a
+    useful check; these are.
+    """
+    reasons: list[str] = []
+
+    # A v1 recipe should never have duplicate keys - that's a v0 selector
+    # idiom, resolved into `if`/`then` blocks during conversion. Note the
+    # deliberate absence of ALLOW_DUPLICATE_KEYS here, unlike the v0 read in
+    # _convert().
+    # Therefore a duplicate key surviving into v1 output would mean a merge
+    # failed.
+    try:
+        RecipeReader(v1_content)
+    except Exception as exc:
+        reasons.append(
+            f"generated recipe.yaml does not re-parse: {type(exc).__name__}: {exc}"
+        )
+
+    for lineno, line in enumerate(v1_content.splitlines(), 1):
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        if _V0_SELECTOR_RE.search(line):
+            reasons.append(f"line {lineno}: leftover v0 selector: {stripped}")
+
+        depth = 0
+        for token in _JINJA_TOKEN_RE.findall(line):
+            if token == "${{":
+                if depth:
+                    reasons.append(f"line {lineno}: nested `${{{{`")
+                depth += 1
+            else:
+                depth -= 1
+                if depth < 0:
+                    reasons.append(f"line {lineno}: unmatched `}}}}`")
+                    break
+        if depth > 0:
+            reasons.append(f"line {lineno}: unclosed `${{{{`")
+
+    return reasons
 
 
 class GenericV0ToV1Migrator(MiniMigrator):
@@ -173,7 +239,15 @@ class GenericV0ToV1Migrator(MiniMigrator):
             return None, [f"crm raised {type(exc).__name__}: {exc}"]
 
         v1_content = _restore_environ_calls(v1_content)
+
+        # crm's message table is not a fully trustworthy signal: it has
+        # produced malformed output (mismatched `${{`/`}}`, a duplicate key
+        # left over from a failed merge) while reporting no warnings or
+        # errors at all. Structurally sanity-check the text itself too,
+        # rather than shipping something broken just because nothing in
+        # msg_tbl complained.
         blocking = self._actionable_messages(msg_tbl)
+        blocking += _malformed_output_reasons(v1_content)
         if blocking:
             return None, blocking
         return v1_content, []

--- a/conda_forge_tick/migrators/v0_to_v1.py
+++ b/conda_forge_tick/migrators/v0_to_v1.py
@@ -372,6 +372,18 @@ class GenericV0ToV1Migrator(MiniMigrator):
         """
         return _to_spdx_generic(lic)
 
+    def _build_script_review_reasons(self, build_sh: str) -> list[str]:
+        """Extension point: return non-blocking reasons to flag ``build.sh``
+        for manual review after an otherwise-successful conversion.
+
+        ``build.sh`` itself is never inspected or rewritten by this class -
+        crm's conversion is schema-only as of now. This is just a place
+        for subclasses to surface ecosystem-specific red flags (e.g. a
+        leftover platform-specific workaround) that are worth a maintainer's
+        attention without blocking the conversion itself.
+        """
+        return []
+
     def _convert(self, raw_meta_yaml: str) -> tuple[str | None, list[str]]:
         """Attempt to convert ``raw_meta_yaml`` (schema v0) to a v1 recipe.
 
@@ -444,3 +456,16 @@ class GenericV0ToV1Migrator(MiniMigrator):
         assert v1_content is not None
         (Path(recipe_dir) / "recipe.yaml").write_text(v1_content)
         meta_yaml_path.unlink()
+
+        build_sh_path = Path(recipe_dir) / "build.sh"
+        if build_sh_path.exists():
+            review_reasons = self._build_script_review_reasons(
+                build_sh_path.read_text()
+            )
+            if review_reasons:
+                logger.warning(
+                    "v0 -> v1 conversion for %s succeeded, but build.sh may need "
+                    "manual review:\n%s",
+                    attrs.get("name", recipe_dir),
+                    "\n".join(review_reasons),
+                )

--- a/conda_forge_tick/migrators/v0_to_v1.py
+++ b/conda_forge_tick/migrators/v0_to_v1.py
@@ -2,8 +2,9 @@ import logging
 import re
 import typing
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
+from conda_recipe_manager.licenses.spdx_utils import SpdxUtils
 from conda_recipe_manager.parser._message_table import MessageCategory, MessageTable
 from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConvert
 from conda_recipe_manager.parser.recipe_reader import RecipeReader
@@ -16,6 +17,10 @@ if typing.TYPE_CHECKING:
     from ..migrators_types import AttrsTypedDict
 
 logger = logging.getLogger(__name__)
+
+# Cached like crm's own `RecipeParserConvert._SPDX_UTILS` - parses the ~700
+# entry SPDX database once rather than per lookup.
+_SPDX_UTILS: Final = SpdxUtils()
 
 # Matches a top-level `license:` field's raw value (not `license_family:`/
 # `license_file:` - the colon must follow "license" immediately).
@@ -42,6 +47,12 @@ _V0_SELECTOR_RE = re.compile(r"#\s*\[")
 # A block-mapping `key: "..."` (or `key: '...'`) whose value opens a quote -
 # see _join_folded_quoted_scalars.
 _SCALAR_KEY_RE = re.compile(r"^([ \t]*[\w.-]+:[ \t]*)([\"'])")
+
+# crm's "Could not patch unrecognized license: `X`" warning, so the license
+# string can be pulled back out for GenericV0ToV1Migrator._is_safe_compound_spdx_expression.
+_UNRECOGNIZED_LICENSE_RE = re.compile(
+    r"^Could not patch unrecognized license: `(?P<license>.+)`$"
+)
 
 
 def _find_scalar_close(text: str, quote: str) -> int:
@@ -276,9 +287,36 @@ class GenericV0ToV1Migrator(MiniMigrator):
             *msg_tbl.get_messages(MessageCategory.ERROR),
         ]
         for msg in msg_tbl.get_messages(MessageCategory.WARNING):
-            if not any(ignore in msg for ignore in self.IGNORED_WARNINGS):
-                blocking.append(msg)
+            if any(ignore in msg for ignore in self.IGNORED_WARNINGS):
+                continue
+            unrecognized_license = _UNRECOGNIZED_LICENSE_RE.match(msg)
+            if unrecognized_license and self._is_safe_compound_spdx_expression(
+                unrecognized_license.group("license")
+            ):
+                continue
+            blocking.append(msg)
         return blocking
+
+    def _is_safe_compound_spdx_expression(self, lic: str) -> bool:
+        """Check whether ``lic`` is a two-part ``A OR B`` SPDX expression
+        whose sides are both already exact, valid SPDX identifiers.
+
+        crm's own SPDX matcher deliberately declines to touch *any* license
+        string containing ``AND``/``OR``/``WITH``, even a perfectly valid
+        one, to avoid mangling a compound expression it wasn't designed to
+        parse - so it warns "Could not patch unrecognized license" on an
+        already-correct expression just as readily as a genuinely bad one
+        (real example: r-icenreg's ``LGPL-2.0-only OR LGPL-2.1-only``).
+        Confirming both sides independently resolve to themselves lets us
+        treat that specific warning as safe to ignore - the field is left
+        untouched either way, so there's nothing to rewrite.
+        """
+        parts = lic.split(" OR ")
+        if len(parts) != 2:
+            return False
+        return all(
+            _SPDX_UTILS.find_closest_license_match(part) == part for part in parts
+        )
 
     def _to_spdx(self, lic: str) -> str:
         """Map a legacy license string to its SPDX identifier, if recognized.

--- a/conda_forge_tick/migrators/v0_to_v1.py
+++ b/conda_forge_tick/migrators/v0_to_v1.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from typing import Any
 
 from conda_recipe_manager.parser._message_table import MessageCategory, MessageTable
-from conda_recipe_manager.parser.exceptions import BaseParserException
 from conda_recipe_manager.parser.recipe_parser_convert import RecipeParserConvert
+from conda_recipe_manager.parser.types import RecipeReaderFlags
 
 from conda_forge_tick.migrators.core import MiniMigrator
 
@@ -53,13 +53,23 @@ class GenericV0ToV1Migrator(MiniMigrator):
         not safe to ship unattended, along with the list of messages that
         explain why (empty if the conversion is clean).
         """
-        # crm can *raise* on malformed recipes (ParsingException,
-        # DuplicateKeyException, ...) at construction, before any msg_tbl
-        # exists to record the failure.
+        # Mirrors what the `crm convert` CLI always does: pre-process the raw
+        # text (e.g. rewrites `{{ environ["FOO"] }}`, common in Bioconda/R
+        # recipes' `license_file`, to valid v1 syntax) and allow the ordinary
+        # `key: val  # [selector]` duplicate-key pattern that's otherwise
+        # extremely common in conda-forge recipes.
+        content = RecipeParserConvert.pre_process_recipe_text(raw_meta_yaml)
+
+        # crm can raise - or, on some malformed/unusual recipes (e.g.
+        # multi-output), crash with an unrelated exception - at construction
+        # or during conversion, before any msg_tbl exists to record why. Any
+        # of that means this recipe isn't safe to auto-convert.
         try:
-            converter = RecipeParserConvert(raw_meta_yaml)
+            converter = RecipeParserConvert(
+                content, flags=RecipeReaderFlags.ALLOW_DUPLICATE_KEYS
+            )
             v1_content, msg_tbl, _debug = converter.render_to_v1_recipe_format()
-        except BaseParserException as exc:
+        except Exception as exc:
             return None, [f"crm raised {type(exc).__name__}: {exc}"]
 
         blocking = self._actionable_messages(msg_tbl)

--- a/conda_forge_tick/migrators/v0_to_v1.py
+++ b/conda_forge_tick/migrators/v0_to_v1.py
@@ -37,13 +37,13 @@ class GenericV0ToV1Migrator(MiniMigrator):
     )
 
     def _actionable_messages(self, msg_tbl: MessageTable) -> list[str]:
-        blocking = list(msg_tbl.get_messages(MessageCategory.EXCEPTION))
-        blocking += msg_tbl.get_messages(MessageCategory.ERROR)
-        blocking += [
-            msg
-            for msg in msg_tbl.get_messages(MessageCategory.WARNING)
-            if not any(ignore in msg for ignore in self.IGNORED_WARNINGS)
+        blocking = [
+            *msg_tbl.get_messages(MessageCategory.EXCEPTION),
+            *msg_tbl.get_messages(MessageCategory.ERROR),
         ]
+        for msg in msg_tbl.get_messages(MessageCategory.WARNING):
+            if not any(ignore in msg for ignore in self.IGNORED_WARNINGS):
+                blocking.append(msg)
         return blocking
 
     def _convert(self, raw_meta_yaml: str) -> tuple[str | None, list[str]]:
@@ -70,6 +70,7 @@ class GenericV0ToV1Migrator(MiniMigrator):
             )
             v1_content, msg_tbl, _debug = converter.render_to_v1_recipe_format()
         except Exception as exc:
+            logger.debug("CRM failed to convert", exc_info=exc)
             return None, [f"crm raised {type(exc).__name__}: {exc}"]
 
         blocking = self._actionable_messages(msg_tbl)

--- a/conda_forge_tick/migrators/v0_to_v1.py
+++ b/conda_forge_tick/migrators/v0_to_v1.py
@@ -10,7 +10,7 @@ from conda_recipe_manager.parser.recipe_reader import RecipeReader
 from conda_recipe_manager.parser.types import RecipeReaderFlags
 
 from conda_forge_tick.migrators.core import MiniMigrator
-from conda_forge_tick.migrators.license import _to_spdx
+from conda_forge_tick.migrators.license import _to_spdx as _to_spdx_generic
 
 if typing.TYPE_CHECKING:
     from ..migrators_types import AttrsTypedDict
@@ -40,16 +40,16 @@ _JINJA_TOKEN_RE = re.compile(r"\$\{\{|\}\}")
 _V0_SELECTOR_RE = re.compile(r"#\s*\[")
 
 
-def _normalize_legacy_license(raw_meta_yaml: str) -> str:
+def _normalize_legacy_license(raw_meta_yaml: str, to_spdx) -> str:
     """Rewrite a recognized legacy license string to its SPDX identifier.
 
     crm has its own SPDX-correction pass, but it only catches a handful of
-    common mistakes and doesn't call out to a real SPDX database (see its
-    ``_fix_bad_licenses``). This repo's own ``LicenseMigrator`` already has a
-    broader, battle-tested mapping (e.g. ``GPL (>= 2)`` -> ``GPL-2.0-or-later``)
-    that crm's matcher doesn't know about; apply it first so crm never has a
-    reason to warn "Could not patch unrecognized license" for a string we
-    already know how to fix.
+    common mistakes and doesn't call out to a real SPDX database. ``to_spdx``
+    is a callable mapping a legacy string to its SPDX identifier (a no-op if
+    it doesn't recognize the string) - normally ``GenericV0ToV1Migrator._to_spdx``
+    or a subclass's override of it - applied here so crm never has a reason
+    to warn "Could not patch unrecognized license" for a string we already know
+    how to fix.
     """
 
     def _repl(match: re.Match) -> str:
@@ -59,7 +59,7 @@ def _normalize_legacy_license(raw_meta_yaml: str) -> str:
         if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
             quote = value[0]
             unquoted = value[1:-1]
-        corrected = _to_spdx(unquoted)
+        corrected = to_spdx(unquoted)
         if corrected == unquoted:
             return match.group(0)
         return f"{match.group('prefix')}{quote}{corrected}{quote}"
@@ -206,6 +206,17 @@ class GenericV0ToV1Migrator(MiniMigrator):
                 blocking.append(msg)
         return blocking
 
+    def _to_spdx(self, lic: str) -> str:
+        """Map a legacy license string to its SPDX identifier, if recognized.
+
+        Delegates verbatim to this repo's shared ``LicenseMigrator`` mapping
+        (``migrators/license.py``) - nothing package-specific lives here.
+        Subclasses override this method (not ``IGNORED_WARNINGS``) to layer
+        their own mappings on top without touching the shared table; see
+        ``RV0ToV1Migrator._to_spdx`` for the R-specific "Unlimited" case.
+        """
+        return _to_spdx_generic(lic)
+
     def _convert(self, raw_meta_yaml: str) -> tuple[str | None, list[str]]:
         """Attempt to convert ``raw_meta_yaml`` (schema v0) to a v1 recipe.
 
@@ -216,7 +227,7 @@ class GenericV0ToV1Migrator(MiniMigrator):
         # Fix legacy license strings crm's own matcher won't recognize, and
         # hide `environ["X"]` calls before crm's duplicate-key merge can
         # mangle them - see the two functions' docstrings above.
-        raw_meta_yaml = _normalize_legacy_license(raw_meta_yaml)
+        raw_meta_yaml = _normalize_legacy_license(raw_meta_yaml, self._to_spdx)
         raw_meta_yaml = _hide_environ_calls(raw_meta_yaml)
 
         # Mirrors what the `crm convert` CLI always does otherwise (e.g.

--- a/conda_forge_tick/migrators/v0_to_v1.py
+++ b/conda_forge_tick/migrators/v0_to_v1.py
@@ -54,6 +54,49 @@ _UNRECOGNIZED_LICENSE_RE = re.compile(
     r"^Could not patch unrecognized license: `(?P<license>.+)`$"
 )
 
+# An unindented top-level section header, e.g. `build:` or `build:  # [win]`
+# - see _duplicate_top_level_key_reasons.
+_TOP_LEVEL_KEY_RE = re.compile(r"^([A-Za-z_][\w.-]*):[ \t]*(?:#.*)?$")
+
+
+def _duplicate_top_level_key_reasons(raw_meta_yaml: str) -> list[str]:
+    """Flag a genuinely duplicated, unselectored top-level section (e.g. two
+    full ``build:`` blocks) before crm ever sees it.
+
+    The common, legitimate conda-forge idiom is a duplicated *leaf* key with
+    a selector on each occurrence (``script: ...  # [win]`` /
+    ``script: ...  # [not win]``) - crm's duplicate-key merge handles that
+    correctly. Two unconditional top-level *section* headers with the same
+    name and no selector on either, on the other hand, isn't a pattern crm
+    merges: it just tolerates the duplicate through
+    (``ALLOW_DUPLICATE_KEYS``), and the raw duplicate survives into v1
+    output, where ``_malformed_output_reasons`` catches it only as a bare
+    ``DuplicateKeyException`` - accurate, but not obviously actionable.
+    This is almost always a real authoring mistake in the source recipe
+    (real example: r-loose.rock has two ``build:`` blocks, one with
+    ``noarch: generic`` and one without) that needs a human to reconcile,
+    not something safe to guess at - so we catch it early with a clearer
+    message instead of letting crm run first.
+    """
+    counts: dict[str, int] = {}
+    has_selector: dict[str, bool] = {}
+    for line in raw_meta_yaml.splitlines():
+        match = _TOP_LEVEL_KEY_RE.match(line)
+        if not match:
+            continue
+        key = match.group(1)
+        counts[key] = counts.get(key, 0) + 1
+        if _V0_SELECTOR_RE.search(line):
+            has_selector[key] = True
+
+    return [
+        f"top-level `{key}:` section appears {count} times with no selector "
+        "to distinguish them - likely an authoring mistake in the source "
+        "recipe that needs manual review"
+        for key, count in counts.items()
+        if count > 1 and not has_selector.get(key)
+    ]
+
 
 def _find_scalar_close(text: str, quote: str) -> int:
     r"""Given a quote character, find where it closes in
@@ -336,6 +379,14 @@ class GenericV0ToV1Migrator(MiniMigrator):
         not safe to ship unattended, along with the list of messages that
         explain why (empty if the conversion is clean).
         """
+        # A genuinely duplicated, unselectored top-level section is almost
+        # certainly a source-recipe authoring mistake, not something crm can
+        # safely merge - catch it now with a clear reason rather than
+        # letting crm run first and re-report it as a bare exception later.
+        duplicate_key_reasons = _duplicate_top_level_key_reasons(raw_meta_yaml)
+        if duplicate_key_reasons:
+            return None, duplicate_key_reasons
+
         # Join folded multi-line quoted scalars before crm's line-based reader can misparse a continuation line.
         raw_meta_yaml = _join_folded_quoted_scalars(raw_meta_yaml)
         # Fix legacy license strings crm's own matcher won't recognize.

--- a/tests/test_r_v0_to_v1.py
+++ b/tests/test_r_v0_to_v1.py
@@ -1,0 +1,134 @@
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from conda_forge_tick.migrators import GenericV0ToV1Migrator, RV0ToV1Migrator
+
+# A real, single-output R recipe using the compiler('c')/native/posix/m2w64
+# templating that's near-universal in R feedstocks, plus the
+# `{{ environ["PREFIX"] }}` license_file pattern.
+MAGRITTR_RECIPE = textwrap.dedent(
+    """\
+    {% set version = "2.0.0" %}
+    {% set posix = 'm2-' if win else '' %}
+    {% set native = 'm2w64-' if win else '' %}
+
+    package:
+      name: r-magrittr
+      version: {{ version|replace("-", "_") }}
+
+    source:
+      url:
+        - {{ cran_mirror }}/src/contrib/magrittr_{{ version }}.tar.gz
+      sha256: 05c45943ada9443134caa0ab24db4a962b629f00b755ccf039a2a2a7b2c92ae8
+
+    build:
+      merge_build_host: true  # [win]
+      skip: True   # [win]
+      number: 1
+
+    requirements:
+      build:
+        - {{ compiler('c') }}              # [not win]
+        - {{ compiler('m2w64_c') }}        # [win]
+        - {{ posix }}filesystem        # [win]
+      host:
+        - r-base
+        - {{native}}gmp
+      run:
+        - r-base
+        - {{ native }}gcc-libs         # [win]
+
+    about:
+      home: https://magrittr.tidyverse.org
+      license: MIT
+      license_family: MIT
+      license_file:
+        - {{ environ["PREFIX"] }}/lib/R/share/licenses/MIT
+        - LICENSE
+    """
+)
+
+# A real, multi-output R feedstock recipe (r-base itself) checked into this
+# repo's test fixtures. crm crashes on it with a raw AttributeError (not a
+# BaseParserException) rather than a clean warning/error.
+R_BASE_MULTI_OUTPUT_RECIPE = (
+    Path(__file__).parent / "r-base-feedstock" / "recipe" / "meta.yaml"
+).read_text()
+
+
+def test_generic_migrator_blocks_on_r_specific_warnings():
+    # GenericV0ToV1Migrator has no idea these warnings are safe to ignore;
+    # RV0ToV1Migrator is what extends the ignore-list to cover them.
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(MAGRITTR_RECIPE)
+    assert v1_content is None
+    assert blocking
+    assert all(
+        "ambiguous version constraints" in msg or "license_family" in msg
+        for msg in blocking
+    )
+
+
+def test_convert_clean_with_r_specific_tokens():
+    v1_content, blocking = RV0ToV1Migrator()._convert(MAGRITTR_RECIPE)
+    assert blocking == []
+    assert v1_content is not None
+    assert "schema_version: 1" in v1_content
+    # `{{ environ["PREFIX"] }}` must round-trip to valid v1 syntax, not be
+    # left as invalid `${{ environ["PREFIX"] }}`.
+    assert 'env.get("PREFIX")' in v1_content
+    assert "environ[" not in v1_content
+
+
+def test_convert_skips_multi_output_recipe_instead_of_crashing():
+    v1_content, blocking = RV0ToV1Migrator()._convert(R_BASE_MULTI_OUTPUT_RECIPE)
+    assert v1_content is None
+    assert len(blocking) == 1
+    assert "AttributeError" in blocking[0]
+
+
+@pytest.mark.parametrize(
+    "attrs, should_skip",
+    [
+        (
+            {
+                "name": "r-magrittr",
+                "feedstock_name": "r-magrittr",
+                "raw_meta_yaml": MAGRITTR_RECIPE,
+            },
+            False,
+        ),
+        (
+            {
+                "name": "numpy",
+                "feedstock_name": "numpy",
+                "raw_meta_yaml": "package:\n  name: numpy\n",
+            },
+            True,
+        ),
+        ({"name": "r-foo", "feedstock_name": "r-foo", "raw_meta_yaml": ""}, True),
+    ],
+)
+def test_filter_scopes_to_r_feedstocks(attrs, should_skip):
+    assert RV0ToV1Migrator().filter(attrs) is should_skip
+
+
+def test_migrate_converts_r_recipe(tmp_path):
+    (tmp_path / "meta.yaml").write_text(MAGRITTR_RECIPE)
+
+    RV0ToV1Migrator().migrate(str(tmp_path), {"name": "r-magrittr"})
+
+    assert not (tmp_path / "meta.yaml").exists()
+    recipe_yaml = tmp_path / "recipe.yaml"
+    assert recipe_yaml.exists()
+    assert "schema_version: 1" in recipe_yaml.read_text()
+
+
+def test_migrate_skips_multi_output_recipe(tmp_path):
+    (tmp_path / "meta.yaml").write_text(R_BASE_MULTI_OUTPUT_RECIPE)
+
+    RV0ToV1Migrator().migrate(str(tmp_path), {"name": "r-base"})
+
+    assert (tmp_path / "meta.yaml").read_text() == R_BASE_MULTI_OUTPUT_RECIPE
+    assert not (tmp_path / "recipe.yaml").exists()

--- a/tests/test_r_v0_to_v1.py
+++ b/tests/test_r_v0_to_v1.py
@@ -108,6 +108,28 @@ def test_convert_skips_multi_output_recipe_instead_of_crashing():
             True,
         ),
         ({"name": "r-foo", "feedstock_name": "r-foo", "raw_meta_yaml": ""}, True),
+        (
+            # No "r-" name/prefix and no "r-base" mention, but maintained by
+            # the conda-forge/r team - still detected as an R feedstock.
+            {
+                "name": "some-cran-tool",
+                "feedstock_name": "some-cran-tool",
+                "raw_meta_yaml": "package:\n  name: some-cran-tool\n",
+                "extra": {"recipe-maintainers": ["conda-forge/r", "someuser"]},
+            },
+            False,
+        ),
+        (
+            # Has an unrelated maintainer team, but no "r-" prefix and no
+            # "r-base" mention - not an R feedstock.
+            {
+                "name": "foo",
+                "feedstock_name": "foo",
+                "raw_meta_yaml": "package:\n  name: foo\n",
+                "extra": {"recipe-maintainers": ["conda-forge/core"]},
+            },
+            True,
+        ),
     ],
 )
 def test_filter_scopes_to_r_feedstocks(attrs, should_skip):

--- a/tests/test_r_v0_to_v1.py
+++ b/tests/test_r_v0_to_v1.py
@@ -1,3 +1,4 @@
+import logging
 import textwrap
 from pathlib import Path
 
@@ -200,3 +201,51 @@ def test_migrate_skips_multi_output_recipe(tmp_path):
 
     assert (tmp_path / "meta.yaml").read_text() == R_BASE_MULTI_OUTPUT_RECIPE
     assert not (tmp_path / "recipe.yaml").exists()
+
+
+# A real pattern (from r-msqc/r-pca3d/r-cffr/r-juniperkernel): the outer
+# `if` already routes osx-64 to a plain install, so the `install_name_tool`
+# fix - nested under `target_platform == osx-64` inside the `else` - is only
+# ever reached when target_platform != osx-64, making it dead code.
+LEGACY_OSX_ARM64_WORKAROUND_BUILD_SH = textwrap.dedent(
+    """\
+    #!/bin/bash
+    if [[ ${target_platform} == osx-64 ]] || [[ ${target_platform} =~ linux.* ]]; then
+      ${R} CMD INSTALL --build .
+    else
+      mv ./* "${PREFIX}"/lib/R/library
+      if [[ ${target_platform} == osx-64 ]]; then
+        install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libR.dylib "${PREFIX}"/lib/R/lib/libR.dylib "${SHARED_LIB}" || true
+      fi
+    fi
+    """
+)
+
+
+def test_build_script_review_reasons_flags_legacy_osx_arm64_workaround():
+    reasons = RV0ToV1Migrator()._build_script_review_reasons(
+        LEGACY_OSX_ARM64_WORKAROUND_BUILD_SH
+    )
+    assert len(reasons) == 1
+    assert "osx-arm64" in reasons[0]
+
+
+def test_build_script_review_reasons_no_false_positive_on_ordinary_script():
+    reasons = RV0ToV1Migrator()._build_script_review_reasons(
+        "#!/bin/bash\n${R} CMD INSTALL --build .\n"
+    )
+    assert reasons == []
+
+
+def test_migrate_warns_about_legacy_osx_arm64_workaround(tmp_path, caplog):
+    (tmp_path / "meta.yaml").write_text(MAGRITTR_RECIPE)
+    (tmp_path / "build.sh").write_text(LEGACY_OSX_ARM64_WORKAROUND_BUILD_SH)
+
+    with caplog.at_level(logging.WARNING):
+        RV0ToV1Migrator().migrate(str(tmp_path), {"name": "r-magrittr"})
+
+    # The conversion still succeeds - this is a non-blocking, informational
+    # flag, not a reason to skip.
+    assert (tmp_path / "recipe.yaml").exists()
+    assert "manual review" in caplog.text
+    assert "osx-arm64" in caplog.text

--- a/tests/test_r_v0_to_v1.py
+++ b/tests/test_r_v0_to_v1.py
@@ -57,6 +57,41 @@ R_BASE_MULTI_OUTPUT_RECIPE = (
     Path(__file__).parent / "r-base-feedstock" / "recipe" / "meta.yaml"
 ).read_text()
 
+# A real pattern (from r-presenceabsence): CRAN's "Unlimited" license,
+# pre-wrapped as the SPDX custom-license reference "LicenseRef-Unlimited".
+# crm's own matcher maps the *bare* string "Unlimited" -> "NOASSERTION", but
+# doesn't recognize the "LicenseRef-" wrapped form, so it warns "Could not
+# patch unrecognized license" unless we strip the wrapper first.
+LICENSEREF_UNLIMITED_RECIPE = textwrap.dedent(
+    """\
+    package:
+      name: r-presenceabsence
+      version: "1.0"
+
+    requirements:
+      host:
+        - r-base
+      run:
+        - r-base
+
+    about:
+      home: https://CRAN.R-project.org/package=PresenceAbsence
+      license: LicenseRef-Unlimited
+      license_family: other
+      summary: test
+    """
+)
+
+
+def test_to_spdx_overrides_r_specific_mapping_and_falls_back_to_shared_one():
+    migrator = RV0ToV1Migrator()
+    # R-specific override.
+    assert migrator._to_spdx("LicenseRef-Unlimited") == "Unlimited"
+    # Falls back to GenericV0ToV1Migrator._to_spdx() -> the shared mapping.
+    assert migrator._to_spdx("GPL-2") == "GPL-2.0-only"
+    # Unrecognized strings are still a no-op.
+    assert migrator._to_spdx("nonsense") == "nonsense"
+
 
 def test_generic_migrator_blocks_on_r_specific_warnings():
     # GenericV0ToV1Migrator has no idea these warnings are safe to ignore;
@@ -79,6 +114,17 @@ def test_convert_clean_with_r_specific_tokens():
     # left as invalid `${{ environ["PREFIX"] }}`.
     assert 'env.get("PREFIX")' in v1_content
     assert "environ[" not in v1_content
+
+
+def test_convert_normalizes_licenseref_unlimited():
+    # Mapping straight to "NOASSERTION" ourselves would backfire: it isn't
+    # itself a recognized SPDX license ID, so crm would just reject it right
+    # back as "unrecognized". Stripping down to the bare "Unlimited" lets
+    # crm's own matcher apply its own agreed correction instead.
+    v1_content, blocking = RV0ToV1Migrator()._convert(LICENSEREF_UNLIMITED_RECIPE)
+    assert blocking == []
+    assert v1_content is not None
+    assert "license: NOASSERTION" in v1_content
 
 
 def test_convert_skips_multi_output_recipe_instead_of_crashing():

--- a/tests/test_v0_to_v1.py
+++ b/tests/test_v0_to_v1.py
@@ -3,6 +3,7 @@ import textwrap
 
 from conda_forge_tick.migrators import GenericV0ToV1Migrator
 from conda_forge_tick.migrators.v0_to_v1 import (
+    _duplicate_top_level_key_reasons,
     _join_folded_quoted_scalars,
     _malformed_output_reasons,
 )
@@ -81,6 +82,15 @@ DUPLICATE_KEY_RECIPE = CLEAN_RECIPE.replace(
     "  script: python setup.py install\n",
     "  script: python setup.py install  # [not win]\n"
     "  script: python setup.py install --old-and-unmanageable  # [win]\n",
+)
+
+# A real pattern (from r-loose.rock): two full, unconditional `build:`
+# sections with no selector on either - most likely a copy-paste mistake in
+# the source recipe (one declares `noarch: generic`, the other doesn't).
+UNSELECTORED_DUPLICATE_BUILD_RECIPE = CLEAN_RECIPE.replace(
+    "build:\n  number: 0\n  script: python setup.py install\n",
+    "build:\n  number: 0\n  noarch: generic\n\n"
+    "build:\n  number: 0\n  script: python setup.py install\n",
 )
 
 # `{{ environ["PREFIX"] }}` (common in license_file fields, not just R/Bioconda
@@ -183,6 +193,36 @@ def test_convert_allows_duplicate_keys():
     assert blocking == []
     assert v1_content is not None
     assert "schema_version: 1" in v1_content
+
+
+def test_duplicate_top_level_key_reasons_flags_unselectored_duplicate():
+    reasons = _duplicate_top_level_key_reasons(UNSELECTORED_DUPLICATE_BUILD_RECIPE)
+    assert len(reasons) == 1
+    assert "top-level `build:` section appears 2 times" in reasons[0]
+
+
+def test_duplicate_top_level_key_reasons_ignores_selectored_leaf_duplicates():
+    # `script:` is duplicated too, but each occurrence carries a selector -
+    # the legitimate, crm-mergeable idiom, not an authoring mistake.
+    assert _duplicate_top_level_key_reasons(DUPLICATE_KEY_RECIPE) == []
+
+
+def test_duplicate_top_level_key_reasons_no_false_positive_on_clean_recipe():
+    assert _duplicate_top_level_key_reasons(CLEAN_RECIPE) == []
+
+
+def test_convert_blocks_on_unselectored_duplicate_top_level_section():
+    # Caught before crm even runs, with a clearer reason than crm's own
+    # DuplicateKeyException would give (see _malformed_output_reasons).
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(
+        UNSELECTORED_DUPLICATE_BUILD_RECIPE
+    )
+    assert v1_content is None
+    assert blocking == [
+        "top-level `build:` section appears 2 times with no selector to "
+        "distinguish them - likely an authoring mistake in the source "
+        "recipe that needs manual review"
+    ]
 
 
 def test_convert_preprocesses_environ_syntax():

--- a/tests/test_v0_to_v1.py
+++ b/tests/test_v0_to_v1.py
@@ -2,7 +2,10 @@ import logging
 import textwrap
 
 from conda_forge_tick.migrators import GenericV0ToV1Migrator
-from conda_forge_tick.migrators.v0_to_v1 import _malformed_output_reasons
+from conda_forge_tick.migrators.v0_to_v1 import (
+    _join_folded_quoted_scalars,
+    _malformed_output_reasons,
+)
 
 CLEAN_RECIPE = textwrap.dedent(
     """\
@@ -110,6 +113,17 @@ LICENSEREF_UNLIMITED_RECIPE = CLEAN_RECIPE.replace(
     "  license: MIT\n", "  license: LicenseRef-Unlimited\n"
 )
 
+# A YAML-folded multi-line double-quoted `summary:` whose continuation line
+# is itself shaped like `'word' more: words` - crm's line-based reader
+# misparses that continuation as its own key/value pair and crashes with a
+# raw ParsingException instead of a clean warning (real example: r-stringi's
+# `about/summary`, a long description CRAN wraps across two physical lines).
+FOLDED_SUMMARY_RECIPE = CLEAN_RECIPE.replace(
+    "  summary: Amazon Web Services Library\n",
+    "  summary: \"Amazon Web Services Library, supports 'S3', 'EC2',\n"
+    "    'SQS' and more. Available regions: us-east-1.\"\n",
+)
+
 # A real pattern (from r-kedd): a duplicate `license_file` key, once per
 # platform selector, where *both* values contain their own `environ["..."]`
 # call. crm's duplicate-key ternary merge mishandles a value that already
@@ -161,6 +175,33 @@ def test_convert_preprocesses_environ_syntax():
     assert v1_content is not None
     assert 'env.get("PREFIX")' in v1_content
     assert "environ[" not in v1_content
+
+
+def test_join_folded_quoted_scalars_joins_multiline_value():
+    joined = _join_folded_quoted_scalars(FOLDED_SUMMARY_RECIPE)
+    assert (
+        "  summary: \"Amazon Web Services Library, supports 'S3', 'EC2',"
+        " 'SQS' and more. Available regions: us-east-1.\"\n"
+    ) in joined
+    # The two folded lines become one - everything else is untouched.
+    assert joined.count("\n") == FOLDED_SUMMARY_RECIPE.count("\n") - 1
+    assert "  license: MIT\n" in joined
+
+
+def test_join_folded_quoted_scalars_leaves_single_line_values_alone():
+    assert _join_folded_quoted_scalars(CLEAN_RECIPE) == CLEAN_RECIPE
+
+
+def test_convert_fixes_folded_quoted_scalar_crash():
+    # Without _join_folded_quoted_scalars, crm raises a raw ParsingException
+    # on this shape rather than a clean, actionable warning.
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(FOLDED_SUMMARY_RECIPE)
+    assert blocking == []
+    assert v1_content is not None
+    assert (
+        "summary: \"Amazon Web Services Library, supports 'S3', 'EC2',"
+        " 'SQS' and more. Available regions: us-east-1.\""
+    ) in v1_content
 
 
 def test_convert_ignores_corrected_legacy_license():

--- a/tests/test_v0_to_v1.py
+++ b/tests/test_v0_to_v1.py
@@ -78,6 +78,11 @@ ENVIRON_RECIPE = CLEAN_RECIPE.replace(
     '  summary: Amazon Web Services Library\n  license_file: {{ environ["PREFIX"] }}/LICENSE\n',
 )
 
+# `GPL-2` is a legacy, non-SPDX license string; crm's own SPDX correction
+# pass patches it to `GPL-2.0-only` in the output (matching this repo's own
+# LicenseMigrator mapping in migrators/license.py) and just logs the change.
+LEGACY_LICENSE_RECIPE = CLEAN_RECIPE.replace("  license: MIT\n", "  license: GPL-2\n")
+
 
 def test_convert_clean_recipe():
     v1_content, blocking = GenericV0ToV1Migrator()._convert(CLEAN_RECIPE)
@@ -106,6 +111,13 @@ def test_convert_preprocesses_environ_syntax():
     assert v1_content is not None
     assert 'env.get("PREFIX")' in v1_content
     assert "environ[" not in v1_content
+
+
+def test_convert_ignores_corrected_legacy_license():
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(LEGACY_LICENSE_RECIPE)
+    assert blocking == []
+    assert v1_content is not None
+    assert "license: GPL-2.0-only" in v1_content
 
 
 def test_convert_blocks_on_unignored_warning():

--- a/tests/test_v0_to_v1.py
+++ b/tests/test_v0_to_v1.py
@@ -464,3 +464,21 @@ def test_migrate_no_op_when_meta_yaml_missing(tmp_path):
 
     assert not (tmp_path / "recipe.yaml").exists()
     assert not (tmp_path / "meta.yaml").exists()
+
+
+def test_build_script_review_reasons_is_a_no_op_by_default():
+    # Base class knows nothing package-specific; subclasses (e.g.
+    # RV0ToV1Migrator) layer their own checks on top - see
+    # tests/test_r_v0_to_v1.py.
+    assert GenericV0ToV1Migrator()._build_script_review_reasons("anything") == []
+
+
+def test_migrate_does_not_warn_about_build_sh_by_default(tmp_path, caplog):
+    (tmp_path / "meta.yaml").write_text(CLEAN_RECIPE)
+    (tmp_path / "build.sh").write_text("#!/bin/bash\n$PYTHON setup.py install\n")
+
+    with caplog.at_level(logging.WARNING):
+        GenericV0ToV1Migrator().migrate(str(tmp_path), {"name": "boto"})
+
+    assert (tmp_path / "recipe.yaml").exists()
+    assert "manual review" not in caplog.text

--- a/tests/test_v0_to_v1.py
+++ b/tests/test_v0_to_v1.py
@@ -2,6 +2,7 @@ import logging
 import textwrap
 
 from conda_forge_tick.migrators import GenericV0ToV1Migrator
+from conda_forge_tick.migrators.v0_to_v1 import _malformed_output_reasons
 
 CLEAN_RECIPE = textwrap.dedent(
     """\
@@ -66,9 +67,18 @@ BLOCKING_WARNING_RECIPE = CLEAN_RECIPE.replace(
 # extremely common and legitimate in conda-forge recipes.
 UNPARSABLE_RECIPE = "package: [name: boto\n"
 
-# A second top-level `build:` key - the common `key: val  # [selector]` /
-# `key: val2  # [other-selector]` pattern conda-forge recipes rely on.
-DUPLICATE_KEY_RECIPE = CLEAN_RECIPE + "\nbuild:\n  number: 1\n"
+# A duplicate `script:` key, once per selector - the common `key: val
+# # [selector]` / `key: val2  # [other-selector]` pattern conda-forge
+# recipes rely on. Note this must actually carry a selector: an unselectored
+# duplicate key (e.g. two unconditional `build:` blocks) doesn't merge into
+# anything - crm's ALLOW_DUPLICATE_KEYS just permits it through, and the
+# genuinely-duplicate key survives into v1 output, which
+# _malformed_output_reasons correctly flags as broken.
+DUPLICATE_KEY_RECIPE = CLEAN_RECIPE.replace(
+    "  script: python setup.py install\n",
+    "  script: python setup.py install  # [not win]\n"
+    "  script: python setup.py install --old-and-unmanageable  # [win]\n",
+)
 
 # `{{ environ["PREFIX"] }}` (common in license_file fields, not just R/Bioconda
 # recipes) needs crm's pre-processing step to become valid v1 syntax; without
@@ -102,6 +112,17 @@ DUPLICATE_ENVIRON_LICENSE_FILE_RECIPE = CLEAN_RECIPE.replace(
     "  summary: Amazon Web Services Library\n"
     "  license_file: '{{ environ[\"PREFIX\"] }}/share/licenses/MIT'  # [unix]\n"
     "  license_file: '{{ environ[\"PREFIX\"] }}\\share\\licenses\\MIT'  # [win]\n",
+)
+
+# Two separate `environ[...]` calls merged into the *same* duplicated value.
+# `_restore_environ_calls` used to only handle the first placeholder in a
+# literal, leaving a second one to get blindly expanded into a `${{ ... }}`
+# nested *inside* the already-templated expression.
+MULTI_ENVIRON_LICENSE_FILE_RECIPE = CLEAN_RECIPE.replace(
+    "  summary: Amazon Web Services Library\n",
+    "  summary: Amazon Web Services Library\n"
+    '  license_file: \'{{ environ["PREFIX"] }}/{{ environ["PKG_NAME"] }}/L\'  # [unix]\n'
+    '  license_file: \'{{ environ["PREFIX"] }}\\{{ environ["PKG_NAME"] }}\\L\'  # [win]\n',
 )
 
 
@@ -171,6 +192,73 @@ def test_convert_fixes_duplicate_environ_license_file_merge():
     assert 'env.get("PREFIX")' in license_file_line
     assert "if win" in license_file_line and "if unix" in license_file_line
     assert "environ[" not in v1_content
+
+
+def test_convert_fixes_multiple_environ_calls_in_one_duplicated_value():
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(
+        MULTI_ENVIRON_LICENSE_FILE_RECIPE
+    )
+    assert blocking == []
+    assert v1_content is not None
+    license_file_lines = [
+        line for line in v1_content.splitlines() if "license_file" in line
+    ]
+    assert len(license_file_lines) == 1
+    license_file_line = license_file_lines[0]
+    # Exactly one top-level `${{ ... }}` block - not one nested inside
+    # another because a second placeholder got expanded in place.
+    assert license_file_line.count("${{") == 1
+    assert license_file_line.count("}}") == 1
+    # Once per branch (win/unix each build their own path from both vars) -
+    # not nested inside one another.
+    assert license_file_line.count('env.get("PREFIX")') == 2
+    assert license_file_line.count('env.get("PKG_NAME")') == 2
+    assert "environ[" not in v1_content
+    assert _malformed_output_reasons(v1_content) == []
+
+
+def test_malformed_output_reasons_catches_mismatched_braces():
+    # A real (simplified) example of what crm produces for a duplicate-key
+    # merge gone wrong, with no warning attached at all.
+    broken = (
+        'license_file: ${{ env.get("PREFIX") }}/GPL if unix else '
+        "env.get(\"PREFIX\") }}\\GPL if win else '' }}\n"
+    )
+    reasons = _malformed_output_reasons(broken)
+    assert reasons
+    assert any("unmatched" in r for r in reasons)
+
+
+def test_malformed_output_reasons_catches_nested_braces():
+    nested = (
+        "license_file: ${{ ('${{ env.get(\"PREFIX\") }}/' ~ "
+        "env.get(\"PKG_NAME\") ~ '/L') if unix else '' }}\n"
+    )
+    reasons = _malformed_output_reasons(nested)
+    assert reasons
+    assert any("nested" in r for r in reasons)
+
+
+def test_malformed_output_reasons_catches_duplicate_keys():
+    duplicate = "about:\n  license_file:\n    - a\n  license_file:\n    - b\n"
+    reasons = _malformed_output_reasons(duplicate)
+    assert reasons
+    assert any("does not re-parse" in r for r in reasons)
+
+
+def test_malformed_output_reasons_no_false_positive_on_good_output():
+    good = textwrap.dedent(
+        """\
+        schema_version: 1
+        about:
+          license_file: ${{ (env.get("PREFIX") ~ '/GPL-3') if unix else (env.get("PREFIX") ~ '\\\\GPL-3') if win else '' }}
+        requirements:
+          build:
+            - if: not win
+              then: ${{ compiler('c') }}
+        """
+    )
+    assert _malformed_output_reasons(good) == []
 
 
 def test_convert_blocks_on_unignored_warning():

--- a/tests/test_v0_to_v1.py
+++ b/tests/test_v0_to_v1.py
@@ -113,6 +113,22 @@ LICENSEREF_UNLIMITED_RECIPE = CLEAN_RECIPE.replace(
     "  license: MIT\n", "  license: LicenseRef-Unlimited\n"
 )
 
+# A real pattern (from r-icenreg): an already-valid compound SPDX
+# expression - two real SPDX ids joined by "OR". crm's matcher declines to
+# touch *any* license string containing AND/OR/WITH on purpose (to avoid
+# mangling a compound expression), so it warns "Could not patch unrecognized
+# license" even though this one needs no fixing at all.
+COMPOUND_OR_LICENSE_RECIPE = CLEAN_RECIPE.replace(
+    "  license: MIT\n", "  license: LGPL-2.0-only OR LGPL-2.1-only\n"
+)
+
+# Same shape, but the left side isn't a real SPDX id - crm is right to warn
+# here, and we shouldn't wave it through just because it looks like the
+# COMPOUND_OR_LICENSE_RECIPE pattern.
+INVALID_COMPOUND_OR_LICENSE_RECIPE = CLEAN_RECIPE.replace(
+    "  license: MIT\n", "  license: NotARealLicense OR LGPL-2.1-only\n"
+)
+
 # A YAML-folded multi-line double-quoted `summary:` whose continuation line
 # is itself shaped like `'word' more: words` - crm's line-based reader
 # misparses that continuation as its own key/value pair and crashes with a
@@ -235,6 +251,36 @@ def test_convert_does_not_know_r_specific_licenseref_unlimited():
     # GenericV0ToV1Migrator has no idea it's safe to rewrite, so it still
     # blocks. See test_r_v0_to_v1.py for the positive (RV0ToV1Migrator) case.
     v1_content, blocking = GenericV0ToV1Migrator()._convert(LICENSEREF_UNLIMITED_RECIPE)
+    assert v1_content is None
+    assert len(blocking) == 1
+    assert "Could not patch unrecognized license" in blocking[0]
+
+
+def test_is_safe_compound_spdx_expression():
+    migrator = GenericV0ToV1Migrator()
+    assert migrator._is_safe_compound_spdx_expression("LGPL-2.0-only OR LGPL-2.1-only")
+    assert migrator._is_safe_compound_spdx_expression("MPL-2.0 OR GPL-3.0-or-later")
+    # One side isn't a real SPDX id.
+    assert not migrator._is_safe_compound_spdx_expression("NotARealLicense OR MIT")
+    # Not a compound expression at all.
+    assert not migrator._is_safe_compound_spdx_expression("MIT")
+    # More than two parts is out of scope.
+    assert not migrator._is_safe_compound_spdx_expression(
+        "MIT OR Apache-2.0 OR BSD-3-Clause"
+    )
+
+
+def test_convert_passes_through_valid_compound_or_license():
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(COMPOUND_OR_LICENSE_RECIPE)
+    assert blocking == []
+    assert v1_content is not None
+    assert "license: LGPL-2.0-only OR LGPL-2.1-only" in v1_content
+
+
+def test_convert_still_blocks_invalid_compound_or_license():
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(
+        INVALID_COMPOUND_OR_LICENSE_RECIPE
+    )
     assert v1_content is None
     assert len(blocking) == 1
     assert "Could not patch unrecognized license" in blocking[0]

--- a/tests/test_v0_to_v1.py
+++ b/tests/test_v0_to_v1.py
@@ -1,0 +1,130 @@
+import logging
+import textwrap
+
+from conda_forge_tick.migrators import GenericV0ToV1Migrator
+
+CLEAN_RECIPE = textwrap.dedent(
+    """\
+    {% set name = "boto" %}
+    {% set version = "2.49.0" %}
+
+    package:
+      name: {{ name|lower }}
+      version: {{ version }}
+
+    source:
+      fn: {{ name }}-{{ version }}.tar.gz
+      url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+      sha256: ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a
+
+    requirements:
+      host:
+        - python
+      run:
+        - python
+
+    build:
+      number: 0
+      script: python setup.py install
+
+    test:
+      commands:
+        - s3put -h
+      imports:
+        - boto
+
+    about:
+      home: https://github.com/boto/boto/
+      license: MIT
+      summary: Amazon Web Services Library
+    """
+)
+
+# Only difference from CLEAN_RECIPE: an `about/license_family` field. crm drops
+# the field and emits a warning that's on GenericV0ToV1Migrator's ignore-list,
+# so this should still be treated as a clean conversion.
+IGNORED_WARNING_RECIPE = CLEAN_RECIPE.replace(
+    "  license: MIT\n",
+    "  license: MIT\n  license_family: MIT\n",
+)
+
+# Replaces the tarball source with an `svn_url`, which crm converts but flags
+# with a non-ignorable warning ("SVN packages are no longer supported").
+BLOCKING_WARNING_RECIPE = CLEAN_RECIPE.replace(
+    "source:\n"
+    "  fn: {{ name }}-{{ version }}.tar.gz\n"
+    "  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz\n"
+    "  sha256: ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a\n",
+    "source:\n  svn_url: https://example.com/svn/boto\n  svn_rev: 123\n",
+)
+
+# A second top-level `build:` key triggers a DuplicateKeyException, which crm
+# raises during parsing before any message table exists.
+UNPARSABLE_RECIPE = CLEAN_RECIPE + "\nbuild:\n  number: 1\n"
+
+
+def test_convert_clean_recipe():
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(CLEAN_RECIPE)
+    assert blocking == []
+    assert v1_content is not None
+    assert "schema_version: 1" in v1_content
+
+
+def test_convert_ignores_known_safe_warnings():
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(IGNORED_WARNING_RECIPE)
+    assert blocking == []
+    assert v1_content is not None
+    assert "schema_version: 1" in v1_content
+
+
+def test_convert_blocks_on_unignored_warning():
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(BLOCKING_WARNING_RECIPE)
+    assert v1_content is None
+    assert len(blocking) == 1
+    assert "SVN packages are no longer supported" in blocking[0]
+
+
+def test_convert_blocks_on_parser_exception():
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(UNPARSABLE_RECIPE)
+    assert v1_content is None
+    assert len(blocking) == 1
+    assert "DuplicateKeyException" in blocking[0]
+
+
+def test_migrate_writes_recipe_yaml_and_removes_meta_yaml(tmp_path):
+    (tmp_path / "meta.yaml").write_text(CLEAN_RECIPE)
+
+    GenericV0ToV1Migrator().migrate(str(tmp_path), {"name": "boto"})
+
+    assert not (tmp_path / "meta.yaml").exists()
+    recipe_yaml = tmp_path / "recipe.yaml"
+    assert recipe_yaml.exists()
+    assert "schema_version: 1" in recipe_yaml.read_text()
+
+
+def test_migrate_skips_recipe_not_safe_to_convert(tmp_path, caplog):
+    (tmp_path / "meta.yaml").write_text(BLOCKING_WARNING_RECIPE)
+
+    with caplog.at_level(logging.WARNING):
+        GenericV0ToV1Migrator().migrate(str(tmp_path), {"name": "boto"})
+
+    assert (tmp_path / "meta.yaml").read_text() == BLOCKING_WARNING_RECIPE
+    assert not (tmp_path / "recipe.yaml").exists()
+    assert "not safe to auto-convert" in caplog.text
+    assert "boto" in caplog.text
+
+
+def test_migrate_skips_unparsable_recipe(tmp_path):
+    (tmp_path / "meta.yaml").write_text(UNPARSABLE_RECIPE)
+
+    GenericV0ToV1Migrator().migrate(str(tmp_path), {"name": "boto"})
+
+    assert (tmp_path / "meta.yaml").read_text() == UNPARSABLE_RECIPE
+    assert not (tmp_path / "recipe.yaml").exists()
+
+
+def test_migrate_no_op_when_meta_yaml_missing(tmp_path):
+    GenericV0ToV1Migrator().migrate(str(tmp_path), {"name": "boto"})
+
+    assert not (tmp_path / "recipe.yaml").exists()
+    assert not (tmp_path / "meta.yaml").exists()

--- a/tests/test_v0_to_v1.py
+++ b/tests/test_v0_to_v1.py
@@ -58,9 +58,25 @@ BLOCKING_WARNING_RECIPE = CLEAN_RECIPE.replace(
     "source:\n  svn_url: https://example.com/svn/boto\n  svn_rev: 123\n",
 )
 
-# A second top-level `build:` key triggers a DuplicateKeyException, which crm
-# raises during parsing before any message table exists.
-UNPARSABLE_RECIPE = CLEAN_RECIPE + "\nbuild:\n  number: 1\n"
+# Malformed YAML (an unterminated flow sequence) that crm can't parse at all,
+# raising before any message table exists. Note a second top-level `build:`
+# key would *not* trigger this: GenericV0ToV1Migrator passes
+# `ALLOW_DUPLICATE_KEYS`, matching what the `crm convert` CLI always does,
+# since that duplicate-key-with-different-selectors pattern is otherwise
+# extremely common and legitimate in conda-forge recipes.
+UNPARSABLE_RECIPE = "package: [name: boto\n"
+
+# A second top-level `build:` key - the common `key: val  # [selector]` /
+# `key: val2  # [other-selector]` pattern conda-forge recipes rely on.
+DUPLICATE_KEY_RECIPE = CLEAN_RECIPE + "\nbuild:\n  number: 1\n"
+
+# `{{ environ["PREFIX"] }}` (common in license_file fields, not just R/Bioconda
+# recipes) needs crm's pre-processing step to become valid v1 syntax; without
+# it, crm leaves behind invalid `${{ environ["PREFIX"] }}` with no warning.
+ENVIRON_RECIPE = CLEAN_RECIPE.replace(
+    "  summary: Amazon Web Services Library\n",
+    '  summary: Amazon Web Services Library\n  license_file: {{ environ["PREFIX"] }}/LICENSE\n',
+)
 
 
 def test_convert_clean_recipe():
@@ -77,6 +93,21 @@ def test_convert_ignores_known_safe_warnings():
     assert "schema_version: 1" in v1_content
 
 
+def test_convert_allows_duplicate_keys():
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(DUPLICATE_KEY_RECIPE)
+    assert blocking == []
+    assert v1_content is not None
+    assert "schema_version: 1" in v1_content
+
+
+def test_convert_preprocesses_environ_syntax():
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(ENVIRON_RECIPE)
+    assert blocking == []
+    assert v1_content is not None
+    assert 'env.get("PREFIX")' in v1_content
+    assert "environ[" not in v1_content
+
+
 def test_convert_blocks_on_unignored_warning():
     v1_content, blocking = GenericV0ToV1Migrator()._convert(BLOCKING_WARNING_RECIPE)
     assert v1_content is None
@@ -88,7 +119,7 @@ def test_convert_blocks_on_parser_exception():
     v1_content, blocking = GenericV0ToV1Migrator()._convert(UNPARSABLE_RECIPE)
     assert v1_content is None
     assert len(blocking) == 1
-    assert "DuplicateKeyException" in blocking[0]
+    assert "ParsingException" in blocking[0]
 
 
 def test_migrate_writes_recipe_yaml_and_removes_meta_yaml(tmp_path):

--- a/tests/test_v0_to_v1.py
+++ b/tests/test_v0_to_v1.py
@@ -83,6 +83,27 @@ ENVIRON_RECIPE = CLEAN_RECIPE.replace(
 # LicenseMigrator mapping in migrators/license.py) and just logs the change.
 LEGACY_LICENSE_RECIPE = CLEAN_RECIPE.replace("  license: MIT\n", "  license: GPL-2\n")
 
+# `GPL (>= 2)` is a legacy license string crm's own SPDX matcher can't map at
+# all (it just warns "Could not patch unrecognized license" and leaves the
+# field as-is) - but this repo's own LicenseMigrator mapping already knows
+# `GPL (>= 2)` -> `GPL-2.0-or-later`, so GenericV0ToV1Migrator normalizes it
+# before crm ever sees it.
+UNRECOGNIZED_LICENSE_RECIPE = CLEAN_RECIPE.replace(
+    "  license: MIT\n", "  license: GPL (>= 2)\n"
+)
+
+# A real pattern (from r-kedd): a duplicate `license_file` key, once per
+# platform selector, where *both* values contain their own `environ["..."]`
+# call. crm's duplicate-key ternary merge mishandles a value that already
+# contains a templated expression, producing malformed, mismatched-brace v1
+# syntax with no warning at all.
+DUPLICATE_ENVIRON_LICENSE_FILE_RECIPE = CLEAN_RECIPE.replace(
+    "  summary: Amazon Web Services Library\n",
+    "  summary: Amazon Web Services Library\n"
+    "  license_file: '{{ environ[\"PREFIX\"] }}/share/licenses/MIT'  # [unix]\n"
+    "  license_file: '{{ environ[\"PREFIX\"] }}\\share\\licenses\\MIT'  # [win]\n",
+)
+
 
 def test_convert_clean_recipe():
     v1_content, blocking = GenericV0ToV1Migrator()._convert(CLEAN_RECIPE)
@@ -118,6 +139,38 @@ def test_convert_ignores_corrected_legacy_license():
     assert blocking == []
     assert v1_content is not None
     assert "license: GPL-2.0-only" in v1_content
+
+
+def test_convert_normalizes_unrecognized_legacy_license():
+    # Without normalization, crm can't map this string at all and warns
+    # "Could not patch unrecognized license" - not on the ignore-list, and
+    # rightly so, since crm leaves the original (non-SPDX) string in place
+    # in that case. GenericV0ToV1Migrator normalizes it first instead, so
+    # crm never has a reason to warn.
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(UNRECOGNIZED_LICENSE_RECIPE)
+    assert blocking == []
+    assert v1_content is not None
+    assert "license: GPL-2.0-or-later" in v1_content
+
+
+def test_convert_fixes_duplicate_environ_license_file_merge():
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(
+        DUPLICATE_ENVIRON_LICENSE_FILE_RECIPE
+    )
+    assert blocking == []
+    assert v1_content is not None
+    # Exactly one well-formed `${{ ... }}` block for license_file, not the
+    # malformed, mismatched-brace output crm produces without the fix.
+    license_file_lines = [
+        line for line in v1_content.splitlines() if "license_file" in line
+    ]
+    assert len(license_file_lines) == 1
+    license_file_line = license_file_lines[0]
+    assert license_file_line.count("${{") == 1
+    assert license_file_line.count("}}") == 1
+    assert 'env.get("PREFIX")' in license_file_line
+    assert "if win" in license_file_line and "if unix" in license_file_line
+    assert "environ[" not in v1_content
 
 
 def test_convert_blocks_on_unignored_warning():

--- a/tests/test_v0_to_v1.py
+++ b/tests/test_v0_to_v1.py
@@ -102,6 +102,14 @@ UNRECOGNIZED_LICENSE_RECIPE = CLEAN_RECIPE.replace(
     "  license: MIT\n", "  license: GPL (>= 2)\n"
 )
 
+# CRAN's "Unlimited" license (real example: r-presenceabsence). This is
+# an R-specific mapping that lives in RV0ToV1Migrator._to_spdx, not here - see
+# test_r_v0_to_v1.py for the positive case; the negative case below confirms
+# it stays confined to the R subclass.
+LICENSEREF_UNLIMITED_RECIPE = CLEAN_RECIPE.replace(
+    "  license: MIT\n", "  license: LicenseRef-Unlimited\n"
+)
+
 # A real pattern (from r-kedd): a duplicate `license_file` key, once per
 # platform selector, where *both* values contain their own `environ["..."]`
 # call. crm's duplicate-key ternary merge mishandles a value that already
@@ -172,6 +180,23 @@ def test_convert_normalizes_unrecognized_legacy_license():
     assert blocking == []
     assert v1_content is not None
     assert "license: GPL-2.0-or-later" in v1_content
+
+
+def test_to_spdx_delegates_to_shared_license_mapping():
+    assert GenericV0ToV1Migrator()._to_spdx("GPL-2") == "GPL-2.0-only"
+    # Unrecognized strings are a no-op, same as the shared _to_spdx().
+    assert GenericV0ToV1Migrator()._to_spdx("nonsense") == "nonsense"
+
+
+def test_convert_does_not_know_r_specific_licenseref_unlimited():
+    # "LicenseRef-Unlimited" -> "Unlimited" is an R-specific mapping (CRAN's
+    # "Unlimited" license) that lives in RV0ToV1Migrator._to_spdx, not here.
+    # GenericV0ToV1Migrator has no idea it's safe to rewrite, so it still
+    # blocks. See test_r_v0_to_v1.py for the positive (RV0ToV1Migrator) case.
+    v1_content, blocking = GenericV0ToV1Migrator()._convert(LICENSEREF_UNLIMITED_RECIPE)
+    assert v1_content is None
+    assert len(blocking) == 1
+    assert "Could not patch unrecognized license" in blocking[0]
 
 
 def test_convert_fixes_duplicate_environ_license_file_merge():


### PR DESCRIPTION
<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

### Description

This is step 2 of the [R feedstock v0 -> v1 migration plan](https://gist.github.com/pb01ka/4d915b2196470ca7c95643c31212b52b), split into two layers, both planned in this PR:

- **`GenericV0ToV1Migrator`** (implemented): a `MiniMigrator` class that only knows the `conda-recipe-manager` (`crm`) conversion mechanics. It has no R-specific logic.
- **`RV0ToV1Migrator`** (in progress, to be pushed in next commit of this PR): an R-specific subclass layered on top of the base class, adding the R-specific pre/post-processing and registered for R feedstocks. See TODOs below for what's still outstanding.

#### Why split into a base class + subclass

Keeping the `crm`-mechanics layer free of R-specifics means:

- It's independently testable against `crm`'s actual behavior (raised exceptions vs. warnings vs. errors), without needing R recipe fixtures.
- It's reusable if we migrate other package clusters through the same v0 -> v1 mechanism later.
- `RV0ToV1Migrator` can extend `IGNORED_WARNINGS` and add its own pre/post-processing without touching the safe-to-auto-convert decision itself.

### TODOs - remaining work in this PR

- [ ] Implement `RV0ToV1Migrator`: layer R-specific pre/post-processing on top of `GenericV0ToV1Migrator`: `{{ compiler('c') }}` / `{{ stdlib('c') }}` / `native`/`posix`/`m2w64` token cleanup (comparable to what `RUCRTCleanup` already does for the ucrt migration), and multi-output handling for CRAN "recommended" vs. non-recommended packages.
- [ ] Re-run the feasibility sample against a larger set of R feedstocks once `RV0ToV1Migrator` exists, to catch any remaining edge cases.
- [ ] Multi-output recipes (e.g. `r-base` itself) currently crash crm's `render_to_v1_recipe_format()` with a raw `AttributeError` in its dependency-upgrade logic; `RV0ToV1Migrator` catches this and skips the recipe rather than converting it. Add a local workaround so multi-output CRAN "recommended" vs. non-recommended recipes actually convert instead of always being skipped.

### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

https://gist.github.com/pb01ka/4d915b2196470ca7c95643c31212b52b
