### PR TITLE
avoid zlib outputs from zlib-ng

### DIFF
--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -79,9 +79,9 @@ def make_outputs_lut_from_graph(gx):
     outputs_lut = defaultdict(set)
     for node_name, node in gx.nodes.items():
         for k in node.get("payload", {}).get("outputs_names", []):
-            if node_name != "pypy-meta" and node_name != "graalpy":
+            if node_name != "pypy-meta" and node_name != "graalpy" and node_name != "zlib-ng":
                 outputs_lut[k].add(node_name)
-            elif k in ["pypy", "graalpy"]:
+            elif k in ["pypy", "graalpy", "zlib-ng"]:
                 # for pypy-meta we only map to pypy and not python or cffi
                 # for graalpy we only map to graalpy and not python or openjdk
                 outputs_lut[k].add(node_name)

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -79,7 +79,11 @@ def make_outputs_lut_from_graph(gx):
     outputs_lut = defaultdict(set)
     for node_name, node in gx.nodes.items():
         for k in node.get("payload", {}).get("outputs_names", []):
-            if node_name != "pypy-meta" and node_name != "graalpy" and node_name != "zlib-ng":
+            if (
+                node_name != "pypy-meta"
+                and node_name != "graalpy"
+                and node_name != "zlib-ng"
+            ):
                 outputs_lut[k].add(node_name)
             elif k in ["pypy", "graalpy", "zlib-ng"]:
                 # for pypy-meta we only map to pypy and not python or cffi


### PR DESCRIPTION
zlib-feedstock provides libzlib and avoid adding zlib-ng into migrations when it's unused.

<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
