### PR TITLE
Mark filtered feedstocks as done

### DIFF
--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -1189,7 +1189,9 @@ def _run_migrator(
                     pred = attrs["pr_info"]["PRed"]
                     nuid = migrator.migrator_uid(attrs)
                     if all(pr["data"] != nuid for pr in pred):
-                        pred.append({'PR': {'number': None, 'state': 'closed'}, 'data': nuid})
+                        pred.append(
+                            {"PR": {"number": None, "state": "closed"}, "data": nuid}
+                        )
             finally:
                 # do this but it is crazy
                 gc.collect()

--- a/conda_forge_tick/auto_tick.py
+++ b/conda_forge_tick/auto_tick.py
@@ -1144,6 +1144,7 @@ def _run_migrator(
             ]
 
             try:
+                all_filtered = True
                 for base_branch in base_branches:
                     with fctx.with_attrs_branch(base_branch):
                         # skip things that do not get migrated
@@ -1169,6 +1170,7 @@ def _run_migrator(
                                 base_branch,
                             )
                         ):
+                            all_filtered = False
                             tried_prs += 1
                             good_prs, break_loop = _run_migrator_on_feedstock_branch(
                                 attrs=attrs,
@@ -1182,6 +1184,12 @@ def _run_migrator(
                             )
                             if break_loop:
                                 break
+                if all_filtered:
+                    # Since all branches are filtered, mark this feedstock as done
+                    pred = attrs["pr_info"]["PRed"]
+                    nuid = migrator.migrator_uid(attrs)
+                    if all(pr["data"] != nuid for pr in pred):
+                        pred.append({'PR': {'number': None, 'state': 'closed'}, 'data': nuid})
             finally:
                 # do this but it is crazy
                 gc.collect()


### PR DESCRIPTION
For eg, when a migrator is already applied (like RISC-V, freethreading) manually, then they are filtered out. We mark the feedstock as done by adding a dummy PR

<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
