### PR TITLE
ignore some problematic packages in riscv migrator

### DIFF
--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -483,6 +483,14 @@ class LinuxRISCV64(_CrossCompileRebuild):
     bump_number = 1
     pkg_list_filename = "linux_riscv64.txt"
     arches = {"linux_riscv64": "linux_64"}
+    ignored_packages = {
+        # already built compiler packages that get caught in a cycle
+        "_openmp_mutex",
+        "ctng-compiler-activation",
+        "ctng-compilers",
+        "gfortran_impl_osx-64",
+        "gfortran_osx-64",
+    }
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("name", "support linux riscv64 platform")


### PR DESCRIPTION
As noted after #6419, the bot still mis-detects zlib (already built in https://github.com/conda-forge/zlib-feedstock/pull/93) as having missing parents. Only that there's no other package left with more parents.

<img width="1622" height="597" alt="image" src="https://github.com/user-attachments/assets/5cd01d28-2a90-4338-857a-e4eda9a1fce0" />

.
My hypothesis is that this is because it's an ancestor of a large cycle induced by some compiler packages (which are easily visible because all have the same number of children and inter-depend on each other; zlib doesn't have the same number because it has additional children that aren't caught up in the cycle).

<img width="1607" height="870" alt="image" src="https://github.com/user-attachments/assets/f0dcc985-8b39-4f95-ba0f-31caeec67e88" />

.
Regardless whether we ignore zlib or not, we need to remove the compiler packages causing the cycle from consideration in the migrator entirely.
