### PR TITLE
ignore intel packages for riscv migration

### DIFF
--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -490,6 +490,9 @@ class LinuxRISCV64(_CrossCompileRebuild):
         "ctng-compilers",
         "gfortran_impl_osx-64",
         "gfortran_osx-64",
+        # intel packages will not be built for riscv
+        "intel-compiler-repack",
+        "intel_repack",
     }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Intel == x86_64; IOW, those feedstocks will not be built for their competitor architecture

See https://github.com/conda-forge/conda-forge-bot-data/commit/56aa3d13a0534be1a88a698018894b9dafab9f3f