### PR TITLE
fix: ignore tests in integration test submodules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,6 @@ preview = true
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 120
+
+[tool.pytest.ini_options]
+addopts = ["--ignore=tests_integration/lib/"]


### PR DESCRIPTION
<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

As it says above...

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->

closes #6450 
