### PR TITLE
fix: ensure we can replace other compiler related vars

### DIFF
--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -475,6 +475,13 @@ def replace_compiler_with_stub(text: str) -> str:
     pattern = r"""\$\{\{.*stdlib\(\s*(["'])([^["']+)\1\s*\).*\}\}"""
     text = re.sub(pattern, lambda m: f"{m.group(2)}_stdlib_stub", text)
 
+    # some recipes use the raw <lang>_compiler variables to ignore run exports
+    pattern = r"\$\{\{.*(?=[\|\s]*)([^\|\s]+)_compiler[\|\s]*.*\}\}"
+    text = re.sub(pattern, lambda m: f"{m.group(1)}_compiler_stub", text)
+
+    pattern = r"\$\{\{.*(?=[\|\s]*)([^\|\s]+)_stdlib[\|\s]*.*\}\}"
+    text = re.sub(pattern, lambda m: f"{m.group(1)}_stdlib_stub", text)
+
     return text
 
 

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -476,10 +476,10 @@ def replace_compiler_with_stub(text: str) -> str:
     text = re.sub(pattern, lambda m: f"{m.group(2)}_stdlib_stub", text)
 
     # some recipes use the raw <lang>_compiler variables to ignore run exports
-    pattern = r"\$\{\{.*(?=[\|\s]*)([^\|\s]+)_compiler[\|\s]*.*\}\}"
+    pattern = r"\$\{\{.*(?=[\|\s]*)([^\|\s]+)_compiler[\|\s]+.*\}\}"
     text = re.sub(pattern, lambda m: f"{m.group(1)}_compiler_stub", text)
 
-    pattern = r"\$\{\{.*(?=[\|\s]*)([^\|\s]+)_stdlib[\|\s]*.*\}\}"
+    pattern = r"\$\{\{.*(?=[\|\s]*)([^\|\s]+)_stdlib[\|\s]+.*\}\}"
     text = re.sub(pattern, lambda m: f"{m.group(1)}_stdlib_stub", text)
 
     return text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -467,6 +467,10 @@ def test_extract_section_from_yaml_text(
         ("${{ blah | x_compiler }}", "x_compiler_stub"),
         ("${{ blah | x_compiler | foo}}", "x_compiler_stub"),
         ("${{x_compiler|foo}}", "x_compiler_stub"),
+        (
+            "          then: cuda-version ${{ cuda_compiler_version }}",
+            "          then: cuda-version ${{ cuda_compiler_version }}",
+        ),
     ],
 )
 def test_replace_compiler_stub(text, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -463,6 +463,10 @@ def test_extract_section_from_yaml_text(
             "fortran_compiler_stub",
         ),
         ('# compiler("fortran")', '# compiler("fortran")'),
+        ("${{ c_compiler }}", "c_compiler_stub"),
+        ("${{ blah | x_compiler }}", "x_compiler_stub"),
+        ("${{ blah | x_compiler | foo}}", "x_compiler_stub"),
+        ("${{x_compiler|foo}}", "x_compiler_stub"),
     ],
 )
 def test_replace_compiler_stub(text, expected):


### PR DESCRIPTION
<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

We need to handle more compiler stubs.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
closes #6458 