### PR TITLE
ignore stuck-in-bot zlib/ncurses for riscv migration

### DIFF
--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -493,6 +493,11 @@ class LinuxRISCV64(_CrossCompileRebuild):
         # intel packages will not be built for riscv
         "intel-compiler-repack",
         "intel_repack",
+        # stuck in nirvana (built manually already)
+        "zlib",
+        # bot detects cycle: llvmdev <- python <- ncurses <- llvmdev;
+        # last edge is spurious though (ncurses was built manually)
+        "ncurses",
     }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
None of the various efforts so far to unblock the riscv migration have worked:
* #6419
* #6439
* #6440
* #6442 
* #6445 

Bite the bullet and ignore zlib, which is still awaiting supposed parents, as well as ncurses, which the bot thinks is part of a cycle. Both have successfully been built manually already:
* https://github.com/conda-forge/ncurses-feedstock/pull/106
* https://github.com/conda-forge/zlib-feedstock/pull/93