### PR TITLE
perf: store outputs_lut as lazy json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ docs/_build/
 
 node_attrs/*
 graph.json
+outputs_to_feedstocks.json
 !tests_integration/resources/empty-graph/graph.json
 pr_json/*
 pr_status/*

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ In this section, we list the collection of jobs that comprise the bot. Each job 
 
 **pypi-mapping** / `bot-pypi-mapping.yml`: Builds a mapping of packages between PyPI and `conda-forge`, and a mapping of python imports to packages using the bot's metadata. The PyPI mapping is written to `conda-forge-bot-data/mappings` and the import mapping is written to `conda-forge-bot-data/import_to_pkg_maps`. This job also generates some internal data stored at `conda-forge-bot-data/ranked_hubs_authorities.json`.
 
-**make-graph** / `bot-make-graph.yml`: Builds the `conda-forge` dependency graph from the feedstocks in `conda-forge-bot-data/all_feedstocks.json`. The graph is written to `conda-forge-bot-data/graph.json`. and specific attributes for each node are written to `conda-forge-bot-data/node_attrs`. This job also performs some schema migrations and might add new files to `conda-forge-bot-data/pr_info` and `conda-forge-bot-data/version_pr_info`.
+**make-graph** / `bot-make-graph.yml`: Builds the `conda-forge` dependency graph from the feedstocks in `conda-forge-bot-data/all_feedstocks.json`. The graph is written to `conda-forge-bot-data/graph.json` and `conda-forge-bot-data/outputs_to_feedstocks.json`. Specific attributes for each node are written to `conda-forge-bot-data/node_attrs`. This job also performs some schema migrations and might add new files to `conda-forge-bot-data/pr_info` and `conda-forge-bot-data/version_pr_info`.
 
 **update-nodes** / `bot-update-nodes.yml`: Updates the feedstock attributes for each graph node in `conda-forge-bot-data/node_attrs`. This job also performs some schema migrations and might add new files to `conda-forge-bot-data/pr_info` and `conda-forge-bot-data/version_pr_info`.
 

--- a/conda_forge_tick/deploy.py
+++ b/conda_forge_tick/deploy.py
@@ -330,7 +330,7 @@ def deploy(
         ]
         if "file" in get_lazy_json_backends():
             drs_to_deploy += CF_TICK_GRAPH_DATA_HASHMAPS
-            drs_to_deploy += ["graph.json"]
+            drs_to_deploy += ["graph.json", "outputs_to_feedstocks.json"]
     else:
         if dirs_to_ignore:
             raise RuntimeError(

--- a/conda_forge_tick/make_graph.py
+++ b/conda_forge_tick/make_graph.py
@@ -362,7 +362,10 @@ def _add_graph_metadata(gx: nx.DiGraph):
     logger.info("making outputs LUT")
     # make the outputs look up table so we can link properly
     # and add this as an attr so we can use later
-    gx.graph["outputs_lut"] = make_outputs_lut_from_graph(gx)
+    lzj = LazyJson("outputs_to_feedstocks.json")
+    with lzj as attrs:
+        attrs.update(make_outputs_lut_from_graph(gx))
+    gx.graph["outputs_lut"] = lzj
 
     logger.info("making strong run exports")
     # collect all of the strong run exports

--- a/conda_forge_tick/models/README.md
+++ b/conda_forge_tick/models/README.md
@@ -27,6 +27,7 @@ conda-forge-bot-data
 │   ├── somepackage.json
 │   └── ...
 ├── graph.json
+├── outputs_to_feedstocks.json
 └── ranked_hubs_authorities.json
 ```
 
@@ -81,6 +82,9 @@ are package names and the edges are dependencies. The node list of this graph is
 the conda-forge ecosystem. The edges are directed from the dependency package to the dependent package.
 
 The nodes have attributes which reference JSON files in the `node_attrs` directory.
+
+### `outputs_to_feedstocks.json`
+A JSON blob holding non-trivial outputs to feedstocks mappings used by the bot.
 
 ### `ranked_hubs_authorities.json`
 Undocumented.


### PR DESCRIPTION
<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

This change should significantly reduce the size of the migration json blobs and bot metadata by storing the outputs-to-feedstocks table only once.

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
