### PR TITLE
perf: skip integration tests on PRs

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -24,59 +24,18 @@ jobs:
     name: Run Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Check if we can skip the merge queue
-        id: merge-queue-ci-skipper
-        uses: cariad-tech/merge-queue-ci-skipper@cf80db21fc70244e36487acc531b3f1118889b0a
-        with:
-          secret: ${{ secrets.AUTOTICK_BOT_TOKEN }}
-
-      - name: Get PR number
-        id: pr-number
-        # this appears to be busted now so using my own code based on the merge_group
-        # parts
-        # uses: bcgov/action-get-pr@35514fa1d4765547da319e967b509363598e8b46 # v0.1.0
-        run: |
-          if [[ ${GITHUB_EVENT_NAME} == "merge_group" ]]; then
-            pr_num=$(echo "${MGHR}" | sed -n 's|.*/pr-\([0-9]\+\)-.*|\1|p')
-          else
-            pr_num=${PR_NUMBER_FOR_PR}
-          fi
-          echo ${pr_num}
-          echo "pr=${pr_num}" >> "$GITHUB_OUTPUT"
-        env:
-          MGHR: ${{ github.event.merge_group.head_ref }}
-          PR_NUMBER_FOR_PR: ${{ github.event.number }}
-
       - name: Check if we should run rest of tests
         id: should-run
         run: |
           if [[ ${GITHUB_EVENT_NAME} == "workflow_dispatch" ]]; then
-            pr_is_fork=false
-          else
-            pr_is_fork=$(gh pr view ${PR_NUMBER} --json headRepositoryOwner | jq '.headRepositoryOwner.login != "conda-forge"')
-          fi
-
-          if [[ ${pr_is_fork} == "true" ]]; then
-            if [[ ${GITHUB_EVENT_NAME} == "merge_group" ]]; then
-              final_should_run=true
-            else
-              final_should_run=false
-            fi
-          elif [[ ${GITHUB_EVENT_NAME} == "workflow_dispatch" ]]; then
+            final_should_run=true
+          elif [[ ${GITHUB_EVENT_NAME} == "merge_group" ]]; then
             final_should_run=true
           else
-            final_should_run=${MQ_CI_SKIP}
-          fi
-          echo "should-run=${final_should_run}" >> "$GITHUB_OUTPUT"
+            final_should_run=false
 
-          echo "pr number: ${PR_NUMBER}"
-          echo "pr is fork: ${pr_is_fork}"
-          echo "merge queue CI needs to run: ${MQ_CI_SKIP}"
+          echo "should-run=${final_should_run}" >> "$GITHUB_OUTPUT"
           echo "should run: ${final_should_run}"
-        env:
-          MQ_CI_SKIP: ${{ steps.merge-queue-ci-skipper.outputs.skip-check != 'true' }}
-          PR_NUMBER: ${{ steps.pr-number.outputs.pr }}
-          GH_TOKEN: ${{ github.token }}
 
       - name: free disk space
         if: ${{ steps.should-run.outputs.should-run == 'true' }}

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -9,7 +9,7 @@ on:
 # Integration tests interact with GitHub resources in the integration test infrastructure and therefore
 # cannot run concurrently with other integration tests.
 concurrency:
-  group: conda-forge-bot-integration-tests
+  group: conda-forge-bot-integration-tests${{ github.event_name == 'pull_request' && '-pr' || ''  }}
   cancel-in-progress: false
 
 env:
@@ -33,6 +33,7 @@ jobs:
             final_should_run=true
           else
             final_should_run=false
+          fi
 
           echo "should-run=${final_should_run}" >> "$GITHUB_OUTPUT"
           echo "should run: ${final_should_run}"


### PR DESCRIPTION
<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

This PR skips the integration tests for PRs in favor of running only in the merge queue. We can run them via workflow dispatch if we need to.

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
