### PR TITLE
perf: make migrators in parallel

### DIFF
--- a/.github/workflows/bot-make-migrators.yml
+++ b/.github/workflows/bot-make-migrators.yml
@@ -197,7 +197,6 @@ jobs:
     name: clean-up-migrators
     runs-on: "ubuntu-latest"
     needs:
-      - list-migrators
       - make-migrators
     defaults:
       run:

--- a/.github/workflows/bot-make-migrators.yml
+++ b/.github/workflows/bot-make-migrators.yml
@@ -8,12 +8,101 @@ on:
 concurrency: bot-make-migrators
 
 jobs:
-  make-migrators:
-    name: make-migrators
+  list-migrators:
+    name: list-migrators
     runs-on: "ubuntu-latest"
     defaults:
       run:
         shell: bash -leo pipefail {0}
+
+    steps:
+      - name: free disk space
+        uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
+          remove_swap: true
+          remove_packages: "azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox postgresql* temurin-* *llvm* mysql* dotnet-sdk-*"
+          remove_packages_one_command: true
+          rm_cmd: "rmz"
+
+      - name: get latest release
+        id: latest_release
+        run: |
+          tag_name=$(gh api repos/conda-forge/conda-forge-bot/releases/latest --jq '.tag_name')
+          echo "latest release: ${tag_name}"
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.latest_release.outputs.tag_name }}
+          path: conda-forge-bot
+
+      - uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
+        with:
+          environment-file: conda-forge-bot/conda-lock.yml
+          environment-name: conda-forge-bot
+          condarc-file: conda-forge-bot/autotick-bot/condarc
+
+      - name: do local setup and stop me if needed
+        run: |
+          cd conda-forge-bot
+          python autotick-bot/stop_me_if_needed.py
+
+      - name: install bot code
+        if: success() && ! env.CI_SKIP
+        run: |
+          source conda-forge-bot/autotick-bot/install_bot_code.sh --no-clean-disk-space
+        env:
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+
+      - name: list migrators
+        if: success() && ! env.CI_SKIP
+        run: |
+          pushd cf-graph
+
+          export RUN_URL="https://github.com/conda-forge/conda-forge-bot/actions/runs/${RUN_ID}"
+          conda-forge-tick make-migrators --list --filename=../migrators.txt
+        env:
+          CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars.CF_TICK_GRAPH_DATA_BACKENDS }}"
+          MONGODB_CONNECTION_STRING: ${{ secrets.MONGODB_CONNECTION_STRING }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+
+      - name: upload migrator list
+        if: success() && ! env.CI_SKIP
+        uses: actions/upload-artifact@v4
+        with:
+          name: old-migrators-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            migrators.txt
+
+      - name: bump on fail
+        if: github.ref == 'refs/heads/main' && failure() && ! env.CI_SKIP
+        run: |
+          export ACTION_URL="https://github.com/conda-forge/conda-forge-bot/actions/runs/${RUN_ID}"
+          python conda-forge-bot/autotick-bot/bump_bot_team.py
+        env:
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          ACTION_NAME: ${{ github.workflow }}
+
+  make-migrators:
+    name: make-migrators
+    runs-on: "ubuntu-latest"
+    needs: list-migrators
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
+    env:
+      N_JOBS: 6
+    strategy:
+      matrix:
+        job_number: [1, 2, 3, 4, 5, 6]
 
     steps:
       - name: free disk space
@@ -66,9 +155,121 @@ jobs:
           pushd cf-graph
 
           export RUN_URL="https://github.com/conda-forge/conda-forge-bot/actions/runs/${RUN_ID}"
-          conda-forge-tick make-migrators --list --filename=../old_migrators.txt
-          conda-forge-tick make-migrators --filename=../new_migrators.txt
-          conda-forge-tick make-migrators --clean-up=../old_migrators.txt,../new_migrators.txt
+          conda-forge-tick make-migrators \
+            --filename=../migrators.txt \
+            --job=${{ matrix.job_number }} --n-jobs=${{ env.N_JOBS }}
+        env:
+          CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars.CF_TICK_GRAPH_DATA_BACKENDS }}"
+          MONGODB_CONNECTION_STRING: ${{ secrets.MONGODB_CONNECTION_STRING }}
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+
+      - name: deploy
+        if: github.ref == 'refs/heads/main' && always() && ! env.CI_SKIP
+        run: |
+          pushd cf-graph
+
+          export RUN_URL="https://github.com/conda-forge/conda-forge-bot/actions/runs/${RUN_ID}"
+          conda-forge-tick deploy-to-github --no-pull
+        env:
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+
+      - name: upload migrator list
+        if: success() && ! env.CI_SKIP
+        uses: actions/upload-artifact@v4
+        with:
+          name: new-migrators-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.job_number }}
+          path: |
+            migrators.txt
+
+      - name: bump on fail
+        if: github.ref == 'refs/heads/main' && failure() && ! env.CI_SKIP
+        run: |
+          export ACTION_URL="https://github.com/conda-forge/conda-forge-bot/actions/runs/${RUN_ID}"
+          python conda-forge-bot/autotick-bot/bump_bot_team.py
+        env:
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          ACTION_NAME: ${{ github.workflow }}
+
+  clean-up-migrators:
+    name: clean-up-migrators
+    runs-on: "ubuntu-latest"
+    needs:
+      - list-migrators
+      - make-migrators
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
+
+    steps:
+      - name: free disk space
+        uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
+          remove_swap: true
+          remove_packages: "azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox postgresql* temurin-* *llvm* mysql* dotnet-sdk-*"
+          remove_packages_one_command: true
+          rm_cmd: "rmz"
+
+      - name: get latest release
+        id: latest_release
+        run: |
+          tag_name=$(gh api repos/conda-forge/conda-forge-bot/releases/latest --jq '.tag_name')
+          echo "latest release: ${tag_name}"
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.latest_release.outputs.tag_name }}
+          path: conda-forge-bot
+
+      - uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
+        with:
+          environment-file: conda-forge-bot/conda-lock.yml
+          environment-name: conda-forge-bot
+          condarc-file: conda-forge-bot/autotick-bot/condarc
+
+      - name: do local setup and stop me if needed
+        run: |
+          cd conda-forge-bot
+          python autotick-bot/stop_me_if_needed.py
+
+      - name: install bot code
+        if: success() && ! env.CI_SKIP
+        run: |
+          source conda-forge-bot/autotick-bot/install_bot_code.sh --no-clean-disk-space
+        env:
+          BOT_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}
+
+      - name: download old migrator list
+        if: success() && ! env.CI_SKIP
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: old-migrators-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: download new migrator lists
+        if: success() && ! env.CI_SKIP
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: new-migrators-${{ github.run_id }}-${{ github.run_attempt }}-*
+
+      - name: clean up migrators
+        if: success() && ! env.CI_SKIP
+        run: |
+          cat new-migrators-${{ github.run_id }}-${{ github.run_attempt }}-*/migrators.txt > new_migrators.txt
+
+          pushd cf-graph
+
+          export RUN_URL="https://github.com/conda-forge/conda-forge-bot/actions/runs/${RUN_ID}"
+          conda-forge-tick make-migrators \
+            --clean-up=../old-migrators-${{ github.run_id }}-${{ github.run_attempt }}/migrators.txt,../new_migrators.txt
         env:
           CF_TICK_GRAPH_DATA_BACKENDS: "${{ vars.CF_TICK_GRAPH_DATA_BACKENDS }}"
           MONGODB_CONNECTION_STRING: ${{ secrets.MONGODB_CONNECTION_STRING }}


### PR DESCRIPTION
<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

This PR changes the code to make all of the migrators in parallel. We will have test it live and baby sit. Might not happen until next week.

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
