### PR TITLE
use only run requirements for noarch folding

### DIFF
--- a/conda_forge_tick/feedstock_parser.py
+++ b/conda_forge_tick/feedstock_parser.py
@@ -150,6 +150,11 @@ def _extract_requirements(meta_yaml, outputs_to_keep=None):
 
     if outputs_to_keep:
         metas = []
+        # a package without an explicit `outputs:` section is itself the
+        # (implicit) single output, so keep its top-level requirements too
+        # if that output is one of the ones we want
+        if meta_yaml.get("package", {}).get("name") in outputs_to_keep:
+            metas.append(meta_yaml)
         for output in meta_yaml.get("outputs", []) or []:
             if output.get("name") in outputs_to_keep:
                 metas.append(output)

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -92,8 +92,12 @@ def _fold_noarch_node(graph, outputs_lut, node):
             _, output_reqs, _ = _extract_requirements(
                 meta_yaml, outputs_to_keep=needed_outputs
             )
+            # only the *run* deps of the needed output(s) matter to `succ`:
+            # build/host deps (e.g. a build backend like poetry) are only
+            # needed to build this noarch package, not by things that
+            # merely depend on it afterwards
             deps = (
-                get_deps_from_outputs_lut(_requirement_names(output_reqs), outputs_lut)
+                get_deps_from_outputs_lut(output_reqs.get("run", set()), outputs_lut)
                 & preds
             )
         else:

--- a/tests/test_arch_noarch_folding.py
+++ b/tests/test_arch_noarch_folding.py
@@ -97,3 +97,53 @@ def test_filter_stubby_and_ignored_nodes_folds_noarch():
     assert "rich" not in gx.nodes
     assert not gx.has_edge("ipywidgets", "anaconda-cli-base")
     assert gx.has_edge("ipywidgets", "jupyter-thing")
+
+
+def _single_output_payload():
+    # mirrors conda-forge/archspec-feedstock: archspec has no explicit
+    # `outputs:` section (it's an implicit single output), and is built with
+    # poetry (a host-only build backend). Consumers of archspec only need it
+    # at run time and must not gain an edge from poetry (or anything poetry
+    # itself needs, like rapidfuzz).
+    meta_yaml = {
+        "package": {"name": "archspec"},
+        "build": {"noarch": "python"},
+        "requirements": {"host": ["python", "poetry"], "run": ["python"]},
+    }
+    return {
+        "meta_yaml": meta_yaml,
+        "outputs_names": {"archspec"},
+        "requirements": {
+            "build": set(),
+            "host": {"python", "poetry"},
+            "run": {"python"},
+            "test": set(),
+        },
+    }
+
+
+def test_fold_noarch_node_single_output_only_forwards_run_deps():
+    gx = nx.DiGraph()
+    gx.add_node("python", payload={"outputs_names": {"python"}, "requirements": {}})
+    gx.add_node("poetry", payload={"outputs_names": {"poetry"}, "requirements": {}})
+    gx.add_node("archspec", payload=_single_output_payload())
+    gx.add_node(
+        "conda",
+        payload={
+            "outputs_names": {"conda"},
+            "requirements": {"host": set(), "run": {"archspec"}},
+        },
+    )
+
+    gx.add_edge("python", "archspec")
+    gx.add_edge("poetry", "archspec")
+    gx.add_edge("archspec", "conda")
+
+    outputs_lut = {"archspec": {"archspec"}}
+
+    _fold_noarch_node(gx, outputs_lut, "archspec")
+
+    assert "archspec" not in gx.nodes
+    assert gx.has_edge("python", "conda")
+    # poetry only builds archspec, conda shouldn't depend on it
+    assert not gx.has_edge("poetry", "conda")


### PR DESCRIPTION
<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
