### PR TITLE
Extend `CrossToNativeMigrator` to `osx-arm64`

### DIFF
--- a/conda_forge_tick/migrators/cross_to_native.py
+++ b/conda_forge_tick/migrators/cross_to_native.py
@@ -15,18 +15,20 @@ from conda_forge_tick.utils import (
 class CrossToNativeMigrator(MiniMigrator):
     allowed_schema_versions = {0, 1}
 
-    # platforms to migrate
-    _platforms = {"linux_aarch64"}
-    # build platforms where default = github_actions
-    _gha_platforms = {"linux_64"}
+    # migrated platforms -> their default CI providers
+    _platform_providers = {
+        "linux_aarch64": "github_actions",
+        "osx_arm64": "azure",
+    }
 
     def _migrate_platform(self, platform: str, cfyaml: CondaForgeYamlContents) -> bool:
         build_platform = cfyaml.get("build_platform", {}).get(platform)
         if build_platform is None:
             return False
         provider = cfyaml.get("provider", {}).get(build_platform, "default")
-        return provider == "github_actions" or (
-            provider == "default" and build_platform in self._gha_platforms
+        return platform in self._platform_providers and provider in (
+            self._platform_providers[platform],
+            "default",
         )
 
     def filter(self, attrs: "AttrsTypedDict", not_bad_str_start: str = "") -> bool:
@@ -36,7 +38,7 @@ class CrossToNativeMigrator(MiniMigrator):
 
         # TODO: check if there are any relevant cross-targets
         cfyaml = attrs.get("conda-forge.yml", {})
-        for platform in self._platforms:
+        for platform in self._platform_providers:
             if self._migrate_platform(platform, cfyaml):
                 return False
         return True
@@ -46,7 +48,7 @@ class CrossToNativeMigrator(MiniMigrator):
         with open(cfyaml_path) as fp:
             cfyaml = yaml_safe_load(fp)
 
-        for platform in self._platforms:
+        for platform in self._platform_providers:
             if not self._migrate_platform(platform, cfyaml):
                 continue
 

--- a/tests/test_cross_to_native.py
+++ b/tests/test_cross_to_native.py
@@ -20,12 +20,12 @@ YAML_PATHS = [
 ]
 
 
-@pytest.mark.parametrize("provider", [None, "default", "github_actions"])
+@pytest.mark.parametrize("provider", [None, "azure", "default", "github_actions"])
 @pytest.mark.parametrize("recipe_version", [0, 1])
 def test_cross_to_native(
     tmp_path: Path, provider: str | None, recipe_version: int
 ) -> None:
-    """Test successfully migrating cross to native."""
+    """Test cross-builds with different providers."""
     in_yaml = (
         YAML_PATHS[recipe_version] / "version_cfyaml_cleanup_simple.yaml"
     ).read_text()
@@ -44,6 +44,8 @@ build_platform:
         input_yaml += f"""\
 provider:
   linux_64: {provider}
+  osx_64: {provider}
+  win_64: {provider}
 """
 
     cfyaml = tmp_path / "conda-forge.yml"
@@ -64,28 +66,43 @@ provider:
         recipe_version=recipe_version,
     )
 
+    expected_build_platforms = ""
+    if provider == "azure":
+        expected_build_platforms += "  linux_aarch64: linux_64\n"
+    expected_build_platforms += "  linux_ppc64le: linux_64\n"
+    if provider == "github_actions":
+        expected_build_platforms += "  osx_arm64: osx_64\n"
+    expected_build_platforms += "  win_arm64: win_64\n"
+
     expected_providers = ""
     if provider is not None:
         expected_providers += f"  linux_64: {provider}\n"
+    if provider != "azure":
+        expected_providers += "  linux_aarch64: default\n"
+    if provider is not None:
+        expected_providers += f"  osx_64: {provider}\n"
+    if provider != "github_actions":
+        expected_providers += "  osx_arm64: default\n"
+    if provider is not None:
+        expected_providers += f"  win_64: {provider}\n"
 
     assert (
         cfyaml.read_text()
         == f"""\
 build_platform:
-  linux_ppc64le: linux_64
-  osx_arm64: osx_64
-  win_arm64: win_64
+{expected_build_platforms}\
 provider:
 {expected_providers}\
-  linux_aarch64: default
 """
     )
 
 
-@pytest.mark.parametrize("provider_platform", ["linux_64", "linux_aarch64"])
+@pytest.mark.parametrize(
+    "provider_platform", ["linux_64", "linux_aarch64", "osx_64", "osx_arm64"]
+)
 @pytest.mark.parametrize("recipe_version", [0, 1])
 def test_no_cross(tmp_path: Path, provider_platform: str, recipe_version: int) -> None:
-    """Test package with no aarch64 build and with native aarch64 build."""
+    """Test package with no cross builds."""
     in_yaml = (
         YAML_PATHS[recipe_version] / "version_cfyaml_cleanup_simple.yaml"
     ).read_text()
@@ -96,47 +113,6 @@ def test_no_cross(tmp_path: Path, provider_platform: str, recipe_version: int) -
     input_yaml = f"""\
 provider:
   {provider_platform}: default
-"""
-
-    cfyaml = tmp_path / "conda-forge.yml"
-    cfyaml.write_text(input_yaml)
-
-    run_test_migration(
-        m=VERSION_CF,
-        inp=in_yaml,
-        output=out_yaml,
-        kwargs={"new_version": "0.9"},
-        prb="Dependencies have been updated if changed",
-        mr_out={
-            "migrator_name": Version.name,
-            "migrator_version": Version.migrator_version,
-            "version": "0.9",
-        },
-        tmp_path=tmp_path,
-        recipe_version=recipe_version,
-    )
-
-    assert cfyaml.read_text() == input_yaml
-
-
-@pytest.mark.parametrize("recipe_version", [0, 1])
-def test_azure(tmp_path: Path, recipe_version: int) -> None:
-    """Test package using non-GHA runner."""
-    in_yaml = (
-        YAML_PATHS[recipe_version] / "version_cfyaml_cleanup_simple.yaml"
-    ).read_text()
-    out_yaml = (
-        YAML_PATHS[recipe_version] / "version_cfyaml_cleanup_simple_correct.yaml"
-    ).read_text()
-
-    input_yaml = """\
-build_platform:
-  linux_aarch64: linux_64
-  linux_ppc64le: linux_64
-  osx_arm64: osx_64
-  win_arm64: win_64
-provider:
-  linux_64: azure
 """
 
     cfyaml = tmp_path / "conda-forge.yml"


### PR DESCRIPTION
<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

<!-- Please describe your PR here. -->
As discussed in #6251, extend the `CrossToNativeMigrator` to migrate also `osx-arm64` builds on Azure.  I was incorrect in my previous PR, and Azure does support native `osx-arm64` builds.

While at it, streamline the test a bit.


#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
