### PR TITLE
fix: use a single exp backoff for lazy json

### DIFF
--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -37,8 +37,8 @@ from requests.structures import CaseInsensitiveDict
 from conda_forge_tick import sensitive_env
 from conda_forge_tick.lazy_json_backends import (
     LazyJson,
-    _retry_sequence,
     _test_and_raise_besides_file_not_exists,
+    lazy_json_retry_sequence,
 )
 
 from .executors import lock_git_operation
@@ -1990,7 +1990,7 @@ def push_file_via_gh_api(pth: str, repo_full_name: str, msg: str) -> None:
     with open(pth) as f:
         data = f.read()
 
-    for tr, ntries in _retry_sequence():
+    for tr, ntries in lazy_json_retry_sequence():
         try:
             gh = github_client(with_app_token=True)
             repo = gh.get_repo(repo_full_name)
@@ -2038,7 +2038,7 @@ def delete_file_via_gh_api(pth: str, repo_full_name: str, msg: str) -> None:
     msg : str
         The commit message.
     """
-    for tr, ntries in _retry_sequence():
+    for tr, ntries in lazy_json_retry_sequence():
         try:
             gh = github_client(with_app_token=True)
             repo = gh.get_repo(repo_full_name)

--- a/conda_forge_tick/git_utils.py
+++ b/conda_forge_tick/git_utils.py
@@ -37,6 +37,7 @@ from requests.structures import CaseInsensitiveDict
 from conda_forge_tick import sensitive_env
 from conda_forge_tick.lazy_json_backends import (
     LazyJson,
+    _retry_sequence,
     _test_and_raise_besides_file_not_exists,
 )
 
@@ -1957,16 +1958,6 @@ def close_out_dirty_prs(
         return d
 
     return None
-
-
-def _retry_sequence(num_tries=50, base=2, factor=0.01, max_wait=360):
-    for i in range(num_tries):
-        start = factor * (base**i)
-        end = start * base
-        if end - start > max_wait:
-            end = start + max_wait
-        time.sleep(RNG.uniform(0, end - start))
-        yield i, num_tries
 
 
 def _get_pth_blob_sha_and_content(

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -65,6 +65,16 @@ CF_TICK_GRAPH_DATA_HASHMAPS = [
 CF_TICK_GRAPH_GITHUB_BACKEND_NUM_DIRS = 5
 
 
+def _retry_sequence(num_tries=50, base=2, factor=0.01, max_wait=360):
+    for i in range(num_tries):
+        start = factor * (base**i)
+        end = start * base
+        if end - start > max_wait:
+            end = start + max_wait
+        time.sleep(RNG.uniform(0, end - start))
+        yield i, num_tries
+
+
 def get_sharded_path(file_path, n_dirs=CF_TICK_GRAPH_GITHUB_BACKEND_NUM_DIRS):
     """Compute a sharded location for the LazyJson file."""
     top_dir, file_name = os.path.split(file_path)
@@ -353,10 +363,6 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
     hashmap data across backends.
     """
 
-    _exp_backoff_base: float = 1.5
-    _exp_backoff_ntries: int = 17
-    _exp_backoff_rfrac = 0.5
-
     def __init__(self):
         from conda_forge_tick.git_utils import github_client
 
@@ -402,8 +408,8 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
             "GithubAPILazyJsonBackend SET: (%s, %s) w/ path %s", name, key, pth
         )
 
-        # exponential backoff will be self._exp_backoff_base**tr
-        for tr in range(self._exp_backoff_ntries):
+        # exponential backoff
+        for tr, ntries in _retry_sequence():
             try:
                 try:
                     _cnts = self._repo.get_contents(pth)
@@ -435,21 +441,15 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
                 logger.warning(
                     "failed to push '%s' - trying %d more times",
                     filename,
-                    self._exp_backoff_ntries - tr - 1,
+                    ntries - tr - 1,
                 )
-                if tr == self._exp_backoff_ntries - 1:
+                if tr == ntries - 1:
                     logger.warning(
                         "failed to push '%s'",
                         filename,
                         exc_info=e,
                     )
                     raise e
-                else:
-                    interval = self._exp_backoff_base**tr
-                    interval = self._exp_backoff_rfrac * interval + (
-                        self._exp_backoff_rfrac * RNG.uniform(0, 1) * interval
-                    )
-                    time.sleep(interval)
 
     def hmset(self, name: str, mapping: Mapping[str, str]) -> None:
         for key, value in mapping.items():
@@ -481,8 +481,8 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
             "GithubAPILazyJsonBackend DEL: (%s, %s) w/ path %s", name, key, pth
         )
 
-        # exponential backoff will be self._exp_backoff_base**tr
-        for tr in range(self._exp_backoff_ntries):
+        # exponential backoff
+        for tr, ntries in _retry_sequence():
             try:
                 try:
                     _cnts = self._repo.get_contents(pth)
@@ -502,21 +502,15 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
                 logger.warning(
                     "failed to delete '%s' - trying %d more times",
                     filename,
-                    self._exp_backoff_ntries - tr - 1,
+                    ntries - tr - 1,
                 )
-                if tr == self._exp_backoff_ntries - 1:
+                if tr == ntries - 1:
                     logger.warning(
                         "failed to delete '%s'",
                         filename,
                         exc_info=e,
                     )
                     raise e
-                else:
-                    interval = self._exp_backoff_base**tr
-                    interval = self._exp_backoff_rfrac * interval + (
-                        self._exp_backoff_rfrac * RNG.uniform(0, 1) * interval
-                    )
-                    time.sleep(interval)
 
     def hdel(self, name: str, keys: Iterable[str]) -> None:
         for key in keys:
@@ -543,8 +537,8 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
             "GithubAPILazyJsonBackend GET: (%s, %s) w/ path %s", name, key, pth
         )
 
-        # exponential backoff will be self._exp_backoff_base**tr
-        for tr in range(self._exp_backoff_ntries):
+        # exponential backoff
+        for tr, ntries in _retry_sequence():
             try:
                 cnts = requests.get(
                     f"https://api.github.com/repos/{settings().graph_github_backend_repo}/contents/{pth}",
@@ -556,21 +550,15 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
                 logger.warning(
                     "failed to pull '%s' - trying %d more times",
                     pth,
-                    self._exp_backoff_ntries - tr - 1,
+                    ntries - tr - 1,
                 )
-                if tr == self._exp_backoff_ntries - 1:
+                if tr == ntries - 1:
                     logger.warning(
                         "failed to pull '%s'",
                         pth,
                         exc_info=e,
                     )
                     raise e
-                else:
-                    interval = self._exp_backoff_base**tr
-                    interval = self._exp_backoff_rfrac * interval + (
-                        self._exp_backoff_rfrac * RNG.uniform(0, 1) * interval
-                    )
-                    time.sleep(interval)
 
         assert False, "There is at least one try, so this cannot be reached."
 

--- a/conda_forge_tick/lazy_json_backends.py
+++ b/conda_forge_tick/lazy_json_backends.py
@@ -65,7 +65,7 @@ CF_TICK_GRAPH_DATA_HASHMAPS = [
 CF_TICK_GRAPH_GITHUB_BACKEND_NUM_DIRS = 5
 
 
-def _retry_sequence(num_tries=50, base=2, factor=0.01, max_wait=360):
+def lazy_json_retry_sequence(num_tries=50, base=2, factor=0.01, max_wait=360):
     for i in range(num_tries):
         start = factor * (base**i)
         end = start * base
@@ -409,7 +409,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
         )
 
         # exponential backoff
-        for tr, ntries in _retry_sequence():
+        for tr, ntries in lazy_json_retry_sequence():
             try:
                 try:
                     _cnts = self._repo.get_contents(pth)
@@ -482,7 +482,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
         )
 
         # exponential backoff
-        for tr, ntries in _retry_sequence():
+        for tr, ntries in lazy_json_retry_sequence():
             try:
                 try:
                     _cnts = self._repo.get_contents(pth)
@@ -538,7 +538,7 @@ class GithubAPILazyJsonBackend(LazyJsonBackend):
         )
 
         # exponential backoff
-        for tr, ntries in _retry_sequence():
+        for tr, ntries in lazy_json_retry_sequence():
             try:
                 cnts = requests.get(
                     f"https://api.github.com/repos/{settings().graph_github_backend_repo}/contents/{pth}",

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -28,7 +28,6 @@ from conda_forge_tick.git_utils import (
     GitPlatformError,
     RepositoryNotFoundError,
     _get_pth_blob_sha_and_content,
-    _retry_sequence,
     delete_file_via_gh_api,
     github_client,
     push_file_via_gh_api,
@@ -1868,11 +1867,3 @@ def test_git_utils_bot_app_token():
     gh = github_client(with_app_token=True)
     assert gh is not None
     assert gh.rate_limiting_resettime != 0
-
-
-def test_git_utils_retry_sequence():
-    start = time.time()
-    for _ in _retry_sequence(num_tries=20, base=2, factor=0.01, max_wait=2):
-        pass
-    end = time.time()
-    assert end - start < 20 * 2

--- a/tests/test_lazy_json_backends.py
+++ b/tests/test_lazy_json_backends.py
@@ -27,6 +27,7 @@ from conda_forge_tick.lazy_json_backends import (
     get_lazy_json_primary_backend,
     get_sharded_path,
     lazy_json_override_backends,
+    lazy_json_retry_sequence,
     lazy_json_snapshot,
     lazy_json_transaction,
     load,
@@ -1141,3 +1142,11 @@ def test_lazy_json_file_read_only_backend(tmpdir):
             conda_forge_tick.lazy_json_backends.CF_TICK_GRAPH_DATA_USE_FILE_CACHE = (
                 old_cache
             )
+
+
+def test_lazy_json_lazy_json_retry_sequence():
+    start = time.time()
+    for _ in lazy_json_retry_sequence(num_tries=20, base=2, factor=0.01, max_wait=2):
+        pass
+    end = time.time()
+    assert end - start < 20 * 2


### PR DESCRIPTION
<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

As it says on the tin...

<!-- Please describe your PR here. -->

#### Checklist:

- [ ] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
