### PR TITLE
fix: Fix preserving YAML comments in `CrossToNative` migrator

### DIFF
--- a/conda_forge_tick/migrators/cross_to_native.py
+++ b/conda_forge_tick/migrators/cross_to_native.py
@@ -1,13 +1,12 @@
 from pathlib import Path
 from typing import Any
 
-from ruamel.yaml import YAML
-
 from conda_forge_tick.migrators.core import MiniMigrator
 from conda_forge_tick.migrators_types import (
     AttrsTypedDict,
     CondaForgeYamlContents,
 )
+from conda_forge_tick.utils import get_yaml_parser
 
 
 class CrossToNativeMigrator(MiniMigrator):
@@ -43,9 +42,7 @@ class CrossToNativeMigrator(MiniMigrator):
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
         cfyaml_path = Path(recipe_dir) / "../conda-forge.yml"
-        # copied from conda_forge_yaml_cleanup.py
-        yaml = YAML()
-        yaml.indent(mapping=2, sequence=4, offset=2)
+        yaml = get_yaml_parser()
         with open(cfyaml_path) as fp:
             cfyaml = yaml.load(fp.read())
 

--- a/conda_forge_tick/migrators/cross_to_native.py
+++ b/conda_forge_tick/migrators/cross_to_native.py
@@ -1,14 +1,12 @@
 from pathlib import Path
 from typing import Any
 
+from ruamel.yaml import YAML
+
 from conda_forge_tick.migrators.core import MiniMigrator
 from conda_forge_tick.migrators_types import (
     AttrsTypedDict,
     CondaForgeYamlContents,
-)
-from conda_forge_tick.utils import (
-    yaml_safe_dump,
-    yaml_safe_load,
 )
 
 
@@ -45,8 +43,11 @@ class CrossToNativeMigrator(MiniMigrator):
 
     def migrate(self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any) -> None:
         cfyaml_path = Path(recipe_dir) / "../conda-forge.yml"
+        # copied from conda_forge_yaml_cleanup.py
+        yaml = YAML()
+        yaml.indent(mapping=2, sequence=4, offset=2)
         with open(cfyaml_path) as fp:
-            cfyaml = yaml_safe_load(fp)
+            cfyaml = yaml.load(fp.read())
 
         for platform in self._platform_providers:
             if not self._migrate_platform(platform, cfyaml):
@@ -60,4 +61,4 @@ class CrossToNativeMigrator(MiniMigrator):
             del cfyaml["build_platform"]
 
         with open(cfyaml_path, "w") as fp:
-            yaml_safe_dump(cfyaml, fp)
+            yaml.dump(cfyaml, fp)

--- a/tests/test_cross_to_native.py
+++ b/tests/test_cross_to_native.py
@@ -152,6 +152,12 @@ build_platform:
 
 provider:
   osx_arm64: default
+
+workflow_settings:
+  store_build_artifacts:
+    # do not remove this comment
+    - os: [linux, osx]
+      value: true
 """
 
     cfyaml = tmp_path / "conda-forge.yml"
@@ -177,5 +183,11 @@ provider:
         == """\
 provider:
   osx_arm64: default
+
+workflow_settings:
+  store_build_artifacts:
+    # do not remove this comment
+    - os: [linux, osx]
+      value: true
 """
     )

--- a/tests/test_cross_to_native.py
+++ b/tests/test_cross_to_native.py
@@ -76,15 +76,15 @@ provider:
 
     expected_providers = ""
     if provider is not None:
-        expected_providers += f"  linux_64: {provider}\n"
+        expected_providers += f"""\
+  linux_64: {provider}
+  osx_64: {provider}
+  win_64: {provider}
+"""
     if provider != "azure":
         expected_providers += "  linux_aarch64: default\n"
-    if provider is not None:
-        expected_providers += f"  osx_64: {provider}\n"
     if provider != "github_actions":
         expected_providers += "  osx_arm64: default\n"
-    if provider is not None:
-        expected_providers += f"  win_64: {provider}\n"
 
     assert (
         cfyaml.read_text()


### PR DESCRIPTION
<!--
Thanks for contributing to conda-forge-bot!

We are currently transitioning to a Pydantic-based model documenting the format of the conda-forge dependency graph
data that this bot internally uses (see README).

Please make sure that your changes either do not change the implicit data model or adjust the model in
conda_forge_tick/models appropriately and document any new fields or files. Tick the checkbox below to confirm.

Note that the model exists next to and independent of the actual production code.
-->

#### Description:

Use `ruamel.yaml` directly the same way `CondaForgeYAMLCleanup` migrator does in order to ensure that the original style is preserved.


#### Checklist:

- [x] Pydantic model updated or no update needed

#### Cross-refs, links to issues, etc:

<!-- Please cross-link your PR to any open issues, other PRs, etc. here. -->
Fixes #6663

