### PR TITLE
Prune blas implementations in arch migrations

### DIFF
--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -137,10 +137,8 @@ def _filter_stubby_and_ignored_nodes(graph, outputs_lut, ignored_packages):
     # special handling for meta-packages
     if "blas" in graph.nodes("payload"):
         # blas has many implementations, and its feedstock depends on all of them;
-        # for arch migrations, we generally only need/want blas & openblas.
-        prune(graph, "blas")
-        # restore minimal required edges
-        graph.add_edges_from([("lapack", "blas"), ("openblas", "blas")])
+        # for arch migrations, we generally only need/want lapack & openblas.
+        prune(graph, "blas", keep=["lapack", "openblas"])
 
 
 class ArchRebuild(GraphMigrator):

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -139,6 +139,9 @@ def _filter_stubby_and_ignored_nodes(graph, outputs_lut, ignored_packages):
         # blas has many implementations, and its feedstock depends on all of them;
         # for arch migrations, we generally only need/want lapack & openblas.
         prune(graph, "blas", keep=["lapack", "openblas"])
+        # lapack->blas is a genuine edge; blas->lapack is the bot getting confused
+        # by outputs with the same name that are being built on several feedstocks
+        graph.remove_edges_from([("blas", "lapack")])
 
 
 class ArchRebuild(GraphMigrator):

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -23,6 +23,7 @@ from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.utils import (
     as_iterable,
     pluck,
+    prune,
     yaml_safe_dump,
     yaml_safe_load,
 )
@@ -132,6 +133,14 @@ def _filter_stubby_and_ignored_nodes(graph, outputs_lut, ignored_packages):
             _fold_noarch_node(graph, outputs_lut, node)
     # post-plucking cleanup
     graph.remove_edges_from(nx.selfloop_edges(graph))
+
+    # special handling for meta-packages
+    if "blas" in graph.nodes("payload"):
+        # blas has many implementations, and its feedstock depends on all of them;
+        # for arch migrations, we generally only need/want blas & openblas.
+        prune(graph, "blas")
+        # restore minimal required edges
+        graph.add_edges_from([("lapack", "blas"), ("openblas", "blas")])
 
 
 class ArchRebuild(GraphMigrator):

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -15,7 +15,14 @@ import traceback
 import typing
 import warnings
 from collections import defaultdict
-from collections.abc import Iterable, Mapping, MutableMapping, MutableSequence, Sequence
+from collections.abc import (
+    Collection,
+    Iterable,
+    Mapping,
+    MutableMapping,
+    MutableSequence,
+    Sequence,
+)
 from pathlib import Path
 from types import MethodType
 from typing import (
@@ -1346,7 +1353,7 @@ def pluck(G: nx.DiGraph, node_id: Any) -> None:
         G.add_edges_from(new_edges)
 
 
-def prune(G: nx.DiGraph, node_id: Any) -> None:
+def prune(G: nx.DiGraph, node_id: Any, keep: Collection[Any] = ()) -> None:
     """Remove a node's ancestors that are not needed anywhere else in the graph.
 
     Ancestors of ``node_id`` are its (transitive) dependencies. This function cuts
@@ -1368,16 +1375,24 @@ def prune(G: nx.DiGraph, node_id: Any) -> None:
     ----------
     G : networkx.DiGraph
     node_id : hashable
+    keep : collection of hashable, optional
+        Nodes to exclude from pruning operation.
     """
     if node_id not in G.nodes:
         return
 
+    keep = set(keep)
+
     ancestors = nx.ancestors(G, node_id)
     # if node_id is part of a cycle, ensure it's not considered its own ancestor
     ancestors.discard(node_id)
+    # also remove nodes we want to keep regardless
+    ancestors.difference_update(keep)
 
-    # the main cut: remove the all the dependency edges that feed into node_id
-    G.remove_edges_from([(pred, node_id) for pred in list(G.predecessors(node_id))])
+    # the main cut: remove all the dependency edges that feed into node_id (modulo `keep`)
+    G.remove_edges_from(
+        [(pred, node_id) for pred in list(G.predecessors(node_id)) if pred not in keep],
+    )
 
     # clean-up afterwards: determine which nodes can now be dropped from the graph.
     # A given node is still needed if it's a transitive dependency of something other

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -1376,17 +1376,18 @@ def prune(G: nx.DiGraph, node_id: Any, keep: Collection[Any] = ()) -> None:
     G : networkx.DiGraph
     node_id : hashable
     keep : collection of hashable, optional
-        Nodes to exclude from pruning operation.
+        Nodes to exclude from pruning operation (also extends to their own ancestors!).
     """
     if node_id not in G.nodes:
         return
 
     keep = set(keep)
 
+    # the ancestors of node_id are potentially in scope for removal
     ancestors = nx.ancestors(G, node_id)
     # if node_id is part of a cycle, ensure it's not considered its own ancestor
     ancestors.discard(node_id)
-    # also remove nodes we want to keep regardless
+    # also remove `keep` nodes from the list of candidates for removal
     ancestors.difference_update(keep)
 
     # the main cut: remove all the dependency edges that feed into node_id (modulo `keep`)

--- a/conda_forge_tick/utils.py
+++ b/conda_forge_tick/utils.py
@@ -1346,6 +1346,60 @@ def pluck(G: nx.DiGraph, node_id: Any) -> None:
         G.add_edges_from(new_edges)
 
 
+def prune(G: nx.DiGraph, node_id: Any) -> None:
+    """Remove a node's ancestors that are not needed anywhere else in the graph.
+
+    Ancestors of ``node_id`` are its (transitive) dependencies. This function cuts
+    the dependency edges feeding into ``node_id`` and then drops every ancestor that,
+    after that cut, can no longer reach the rest of the graph along directed edges --
+    i.e. every ancestor that was needed *only* to build ``node_id``.
+
+    Ancestors that are still a (transitive) dependency of some other retained node are
+    kept, as is ``node_id`` itself and everything that depends on it.
+
+    The motivating use case is metapackages such as ``blas``: an arch migration
+    wants ``blas`` and its genuinely shared dependencies, but not the pile of
+    mutually-exclusive BLAS implementations (``mkl``, ``blis``, ...) and their
+    private dependencies (``tbb``, ...) that hang off it.
+
+    This function operates in-place.
+
+    Parameters
+    ----------
+    G : networkx.DiGraph
+    node_id : hashable
+    """
+    if node_id not in G.nodes:
+        return
+
+    ancestors = nx.ancestors(G, node_id)
+    # if node_id is part of a cycle, ensure it's not considered its own ancestor
+    ancestors.discard(node_id)
+
+    # the main cut: remove the all the dependency edges that feed into node_id
+    G.remove_edges_from([(pred, node_id) for pred in list(G.predecessors(node_id))])
+
+    # clean-up afterwards: determine which nodes can now be dropped from the graph.
+    # A given node is still needed if it's a transitive dependency of something other
+    # than node_id's ancestors. Since the direction of the edges is from parent to child,
+    # this means we need to search the reversed graph, i.e. all (grand^N-)parents of
+    # `G.nodes - ancestors`; nodes which aren't reached existed only to build node_id.
+    # There's no deep reason for choosing `bfs_layers` (breadth-first search), except that
+    # it's the only traversal function that returns nodes and allows multiple sources at once,
+    # c.f. https://networkx.org/documentation/stable/reference/algorithms/traversal.html
+    still_needed = set(
+        # we don't care about the layers (i.e. equal distance from sources); unpack everything
+        itertools.chain.from_iterable(
+            nx.bfs_layers(G.reverse(copy=False), list(G.nodes - ancestors)),
+        ),
+    )
+    G.remove_nodes_from(ancestors - still_needed)
+
+    # sanity check: drop anything that got detached from node_id's component by the removal
+    reachables = nx.node_connected_component(G.to_undirected(as_view=True), node_id)
+    G.remove_nodes_from(G.nodes - reachables)
+
+
 def dump_graph_json(gx: nx.DiGraph, filename: str = "graph.json") -> None:
     nld = nx.node_link_data(gx, edges="links")
     links = nld["links"]

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
   - lockfile
   - mamba >=0.23
   - msgpack-python
-  - networkx !=2.8.1
+  - networkx >=2.8.6
   - orjson
   - packaging
   - psutil

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from io import StringIO
 from unittest import mock
 from unittest.mock import MagicMock, mock_open
 
+import networkx as nx
 import pytest
 
 from conda_forge_tick.lazy_json_backends import LazyJson
@@ -18,6 +19,7 @@ from conda_forge_tick.utils import (
     load_existing_graph,
     load_graph,
     parse_munged_run_export,
+    prune,
     replace_compiler_with_stub,
     run_command_hiding_token,
 )
@@ -94,6 +96,94 @@ def test_get_keys_default_none():
         )
         is False
     )
+
+
+@pytest.fixture
+def blas_like_graph():
+    """Provide a dummy graph modeled on the ``blas`` metapackage.
+
+    Edges point from a dependency to the package requiring it (as in the real
+    conda-forge graph). ``blas`` combines several BLAS implementations;
+    ``zlib``/``zstd`` are shared dependencies also used by ``numpy``/``scipy``,
+    while ``tbb``/``libhwloc`` are private to a single implementation.
+    """
+    G = nx.DiGraph()
+    # blas depends on the implementations
+    G.add_edges_from(
+        [
+            ("openblas", "blas"),
+            ("mkl", "blas"),
+            ("mpich", "blas"),
+            ("blis", "blas"),
+        ]
+    )
+    # example of shared low-level deps, also needed by the science stack
+    G.add_edges_from(
+        [
+            ("zlib", "openblas"),
+            ("zlib", "mkl"),
+            ("zstd", "openblas"),
+            ("zstd", "mpich"),
+            ("zlib", "numpy"),
+            ("zstd", "scipy"),
+        ]
+    )
+    # deps private to a single implementation
+    G.add_edges_from([("tbb", "mkl"), ("libhwloc", "mpich")])
+    # children of blas
+    G.add_edges_from([("blas", "numpy"), ("blas", "scipy"), ("numpy", "scipy")])
+    return G
+
+
+def test_prune_removes_exclusive_ancestors(blas_like_graph):
+    G = blas_like_graph
+
+    prune(G, "blas")
+
+    # blas and its children survive, as do the shared deps (needed by numpy/scipy)
+    assert set(G.nodes) == {"blas", "numpy", "scipy", "zlib", "zstd"}
+    # the BLAS implementations and their private deps are gone, with all edges
+    assert set(G.edges) == {
+        ("blas", "numpy"),
+        ("blas", "scipy"),
+        ("numpy", "scipy"),
+        ("zlib", "numpy"),
+        ("zstd", "scipy"),
+    }
+
+
+def test_prune_keeps_ancestors_needed_elsewhere(blas_like_graph):
+    G = blas_like_graph
+    # mkl is now also a direct dependency of numpy -> it (and its private dep
+    # tbb, transitively) must be kept even though blas no longer needs it
+    G.add_edge("mkl", "numpy")
+
+    prune(G, "blas")
+
+    assert set(G.nodes) == {"blas", "numpy", "scipy", "zlib", "zstd", "mkl", "tbb"}
+    assert ("tbb", "mkl") in G.edges
+    assert ("mkl", "numpy") in G.edges
+    assert ("mkl", "blas") not in G.edges
+    # the other implementations are still pruned
+    assert {"openblas", "mpich", "blis", "libhwloc"}.isdisjoint(G.nodes)
+
+
+def test_prune_handles_cycle_through_node_id():
+    G = nx.DiGraph()
+    # blas and lapack feedstocks (from the POV of the bot metadata) form a cycle
+    G.add_edges_from([("blas", "lapack"), ("lapack", "blas")])
+    # mkl is a private, exclusive dependency of blas
+    G.add_edge("mkl", "blas")
+    # numpy depends on blas and lapack
+    G.add_edges_from([("blas", "numpy"), ("lapack", "numpy")])
+
+    prune(G, "blas")
+
+    # lapack is part of the cycle but is still needed by numpy -> kept;
+    # mkl was exclusive to blas -> pruned
+    assert set(G.nodes) == {"blas", "lapack", "numpy"}
+    assert ("lapack", "blas") not in G.edges
+    assert {("blas", "lapack"), ("blas", "numpy"), ("lapack", "numpy")} <= set(G.edges)
 
 
 def test_load_graph():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,6 +168,21 @@ def test_prune_keeps_ancestors_needed_elsewhere(blas_like_graph):
     assert {"openblas", "mpich", "blis", "libhwloc"}.isdisjoint(G.nodes)
 
 
+def test_prune_keep_retains_listed_ancestors_and_their_deps(blas_like_graph):
+    G = blas_like_graph
+
+    prune(G, "blas", keep=["mkl"])
+
+    # mkl is kept even though it is exclusive to blas, and so is its private
+    # dependency tbb
+    assert {"mkl", "tbb"} <= set(G.nodes)
+    assert ("tbb", "mkl") in G.edges
+    # the mkl -> blas edge survives too: edges from `keep` nodes are not cut
+    assert ("mkl", "blas") in G.edges
+    # the other implementations are still pruned
+    assert {"openblas", "mpich", "blis", "libhwloc"}.isdisjoint(G.nodes)
+
+
 def test_prune_handles_cycle_through_node_id():
     G = nx.DiGraph()
     # blas and lapack feedstocks (from the POV of the bot metadata) form a cycle


### PR DESCRIPTION
When looking at the arch migrator pages, e.g. the one for [riscv64](https://conda-forge.org/status/migration/?name=supportlinuxriscv64platform), there's a huge amount of packages that get pulled in through the blas metapackage, and all its many implementations. We don't need all of those to build `blas`, just `lapack` and `openblas` suffice. But the bot can't know that, so provide a function for the graph that prunes such unwanted dependencies (while still keeping those that are needed elsewhere). 

As a concrete example, all the following dependencies lead to `blas`, and none of them are truly necessary for the riscv64 migration: 

<img width="1182" height="687" alt="image" src="https://github.com/user-attachments/assets/a99b6d14-5fbb-40fa-9151-ed59b0b3b96f" />

.
PS. I used some LLM to simplify the graph traversal and for writing tests, but idea/implementation/code/comments are all written by myself.
PPS. The existing `pluck` cannot be used for this purpose, because it explicitly keeps the ancestors and fuses the edges around the removed node.
PPPS. This function is obviously written with broader applicability in mind. We can later also apply it to other tricky meta-packages where necessary or beneficial.
