### PR TITLE
Treat already-migrated predecessors as built in arch migrations

### DIFF
--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -22,6 +22,7 @@ from conda_forge_tick.migrators_types import AttrsTypedDict, MigrationUidTypedDi
 from conda_forge_tick.os_utils import pushd
 from conda_forge_tick.utils import (
     as_iterable,
+    get_keys_default,
     pluck,
     prune,
     yaml_safe_dump,
@@ -150,23 +151,23 @@ def _arches_are_configured(attrs: "AttrsTypedDict", arches: dict) -> bool:
     This reads the state off ``conda-forge.yml``, so it is true for feedstocks that
     were migrated by hand or by a rerender as well as for ones the bot PRed.
 
-    The default is false: an empty ``arches`` means there is nothing to detect, not
-    that the feedstock is configured for everything.
+    Any missing arch fails the check.
     """
-    configured = False
-    for arch in arches:
-        configured_arch = (
-            attrs.get("conda-forge.yml", {}).get("provider", {}).get(arch)
+
+    def _already_has_arch(arch):
+        # This arch has to be in provider or build_platform
+        return get_keys_default(
+            attrs, ["conda-forge.yml", "provider", arch], {}, None
         ) or (
-            attrs.get("conda-forge.yml", {}).get("build_platform", {}).get(arch)
+            get_keys_default(
+                attrs, ["conda-forge.yml", "build_platform", arch], {}, None
+            )
             not in [None, arch]
         )
-        if not configured_arch:
-            # This arch is not in provider or build_platform
-            return False
-        configured = True
 
-    return configured
+    # ternary condition because `all` over an empty list is always true; we want
+    # to default to False rather than marking a feedstock as done
+    return all(_already_has_arch(arch) for arch in arches) if arches else False
 
 
 class ArchRebuild(GraphMigrator):

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -170,7 +170,27 @@ def _arches_are_configured(attrs: "AttrsTypedDict", arches: dict) -> bool:
     return all(_already_has_arch(arch) for arch in arches) if arches else False
 
 
-class ArchRebuild(GraphMigrator):
+class _ArchesConfiguredMixin:
+    """Answers "is this feedstock already building our arches?" off ``conda-forge.yml``.
+
+    Shared by the arch migrators, whose migrated state is visible in the feedstock
+    itself rather than only in the bot's PR records.
+    """
+
+    arches: dict = {}
+
+    def filter_node_migrated(
+        self, attrs: "AttrsTypedDict", not_bad_str_start: str = ""
+    ):
+        return _arches_are_configured(
+            attrs, self.arches
+        ) or super().filter_node_migrated(attrs, not_bad_str_start)  # type: ignore[misc]
+
+    def predecessor_already_migrated(self, attrs: "AttrsTypedDict") -> bool:
+        return _arches_are_configured(attrs, self.arches)
+
+
+class ArchRebuild(_ArchesConfiguredMixin, GraphMigrator):
     """A Migrator that adds aarch64 builds to feedstocks."""
 
     allowed_schema_versions = {0, 1}
@@ -261,16 +281,6 @@ class ArchRebuild(GraphMigrator):
         )
         assert not self.check_solvable, "We don't want to check solvability for aarch!"
 
-    def filter_node_migrated(
-        self, attrs: "AttrsTypedDict", not_bad_str_start: str = ""
-    ):
-        return _arches_are_configured(
-            attrs, self.arches
-        ) or super().filter_node_migrated(attrs, not_bad_str_start)
-
-    def predecessor_already_migrated(self, attrs: "AttrsTypedDict") -> bool:
-        return _arches_are_configured(attrs, self.arches)
-
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
     ) -> MigrationUidTypedDict | Literal[False]:
@@ -330,7 +340,7 @@ class ArchRebuild(GraphMigrator):
         return super().remote_branch(feedstock_ctx) + "_arch"
 
 
-class _CrossCompileRebuild(GraphMigrator):
+class _CrossCompileRebuild(_ArchesConfiguredMixin, GraphMigrator):
     """A Migrator that adds arch platform builds to feedstocks."""
 
     rerender = True
@@ -339,7 +349,6 @@ class _CrossCompileRebuild(GraphMigrator):
 
     ignored_packages: set[str] = set()
     excluded_dependencies: set[str] = set()
-    arches: dict = {}
 
     @property
     def additional_keys(self):
@@ -439,16 +448,6 @@ class _CrossCompileRebuild(GraphMigrator):
             top_level=top_level,
         )
         assert not self.check_solvable, "We don't want to check solvability!"
-
-    def filter_node_migrated(
-        self, attrs: "AttrsTypedDict", not_bad_str_start: str = ""
-    ):
-        return _arches_are_configured(
-            attrs, self.arches
-        ) or super().filter_node_migrated(attrs, not_bad_str_start)
-
-    def predecessor_already_migrated(self, attrs: "AttrsTypedDict") -> bool:
-        return _arches_are_configured(attrs, self.arches)
 
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -144,6 +144,26 @@ def _filter_stubby_and_ignored_nodes(graph, outputs_lut, ignored_packages):
         graph.remove_edges_from([("blas", "lapack")])
 
 
+def _arches_are_configured(attrs: "AttrsTypedDict", arches: dict) -> bool:
+    """Whether the feedstock itself already builds every one of ``arches``.
+
+    This reads the state off ``conda-forge.yml``, so it is true for feedstocks that
+    were migrated by hand or by a rerender as well as for ones the bot PRed.
+    """
+    for arch in arches:
+        configured_arch = (
+            attrs.get("conda-forge.yml", {}).get("provider", {}).get(arch)
+        ) or (
+            attrs.get("conda-forge.yml", {}).get("build_platform", {}).get(arch)
+            not in [None, arch]
+        )
+        if not configured_arch:
+            # This arch is not in provider or build_platform
+            return False
+
+    return True
+
+
 class ArchRebuild(GraphMigrator):
     """A Migrator that adds aarch64 builds to feedstocks."""
 
@@ -238,21 +258,12 @@ class ArchRebuild(GraphMigrator):
     def filter_node_migrated(
         self, attrs: "AttrsTypedDict", not_bad_str_start: str = ""
     ):
-        has_arch_all_arch = True
-        for arch in self.arches:
-            configured_arch = (
-                attrs.get("conda-forge.yml", {}).get("provider", {}).get(arch)
-            ) or (
-                attrs.get("conda-forge.yml", {}).get("build_platform", {}).get(arch)
-                not in [None, arch]
-            )
-            if not configured_arch:
-                # This arch is not in provider or build_platform
-                has_arch_all_arch = False
+        return _arches_are_configured(
+            attrs, self.arches
+        ) or super().filter_node_migrated(attrs, not_bad_str_start)
 
-        return has_arch_all_arch or super().filter_node_migrated(
-            attrs, not_bad_str_start
-        )
+    def predecessor_already_migrated(self, attrs: "AttrsTypedDict") -> bool:
+        return _arches_are_configured(attrs, self.arches)
 
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any
@@ -426,21 +437,12 @@ class _CrossCompileRebuild(GraphMigrator):
     def filter_node_migrated(
         self, attrs: "AttrsTypedDict", not_bad_str_start: str = ""
     ):
-        has_arch_all_arch = True
-        for arch in self.arches:
-            configured_arch = (
-                attrs.get("conda-forge.yml", {}).get("provider", {}).get(arch)
-            ) or (
-                attrs.get("conda-forge.yml", {}).get("build_platform", {}).get(arch)
-                not in [None, arch]
-            )
-            if not configured_arch:
-                # This arch is not in provider or build_platform
-                has_arch_all_arch = False
+        return _arches_are_configured(
+            attrs, self.arches
+        ) or super().filter_node_migrated(attrs, not_bad_str_start)
 
-        return has_arch_all_arch or super().filter_node_migrated(
-            attrs, not_bad_str_start
-        )
+    def predecessor_already_migrated(self, attrs: "AttrsTypedDict") -> bool:
+        return _arches_are_configured(attrs, self.arches)
 
     def migrate(
         self, recipe_dir: str, attrs: "AttrsTypedDict", **kwargs: Any

--- a/conda_forge_tick/migrators/arch.py
+++ b/conda_forge_tick/migrators/arch.py
@@ -149,7 +149,11 @@ def _arches_are_configured(attrs: "AttrsTypedDict", arches: dict) -> bool:
 
     This reads the state off ``conda-forge.yml``, so it is true for feedstocks that
     were migrated by hand or by a rerender as well as for ones the bot PRed.
+
+    The default is false: an empty ``arches`` means there is nothing to detect, not
+    that the feedstock is configured for everything.
     """
+    configured = False
     for arch in arches:
         configured_arch = (
             attrs.get("conda-forge.yml", {}).get("provider", {}).get(arch)
@@ -160,8 +164,9 @@ def _arches_are_configured(attrs: "AttrsTypedDict", arches: dict) -> bool:
         if not configured_arch:
             # This arch is not in provider or build_platform
             return False
+        configured = True
 
-    return True
+    return configured
 
 
 class ArchRebuild(GraphMigrator):

--- a/conda_forge_tick/migrators/core.py
+++ b/conda_forge_tick/migrators/core.py
@@ -958,6 +958,20 @@ class GraphMigrator(Migrator):
 
         return True
 
+    def predecessor_already_migrated(self, attrs: "AttrsTypedDict") -> bool:
+        """If true, treat a predecessor as built even without a bot PR record.
+
+        Migrators whose migrated state is visible in the feedstock itself -- the arch
+        migrators, which read it off ``conda-forge.yml`` -- override this. Without it
+        a parent that was migrated manually or by a rerender never gets a ``PRed``
+        entry, and so blocks all of its children forever: nothing on the feedstock
+        side can add that entry after the fact.
+
+        This deliberately does not consider ``PRed`` records, so that a predecessor
+        with an open migration PR still blocks its children.
+        """
+        return False
+
     def predecessors_not_yet_built(self, attrs: "AttrsTypedDict") -> bool:
         # Check if all upstreams have been built
         if self.graph is None:
@@ -970,6 +984,10 @@ class GraphMigrator(Migrator):
                 attrs.get("feedstock_name", None),
                 [],
             ):
+                continue
+
+            if self.predecessor_already_migrated(payload):
+                logger.debug("already migrated: %s", node)
                 continue
 
             muid = frozen_to_json_friendly(self.migrator_uid(payload))

--- a/tests/test_graph_migrator_predecessors.py
+++ b/tests/test_graph_migrator_predecessors.py
@@ -1,0 +1,74 @@
+import networkx as nx
+
+from conda_forge_tick.migrators.arch import LinuxRISCV64
+from conda_forge_tick.utils import frozen_to_json_friendly
+
+
+def _payload(name, conda_forge_yml=None, pred=None):
+    return {
+        "name": name,
+        "feedstock_name": name,
+        "archived": False,
+        "conda-forge.yml": conda_forge_yml or {},
+        "pr_info": {"PRed": pred or []},
+    }
+
+
+def _graph(parent_payload):
+    # parent -> child, i.e. the child depends on the parent
+    gx = nx.DiGraph()
+    gx.add_node("lapack", payload=parent_payload)
+    gx.add_node("gsl", payload=_payload("gsl"))
+    gx.add_edge("lapack", "gsl")
+    return gx
+
+
+def test_predecessor_migrated_via_build_platform_counts_as_built():
+    # mirrors conda-forge/conda-forge-bot: lapack got linux_riscv64 through a
+    # rerender rather than a bot PR, so it has no PRed record at all. Its
+    # children must not be blocked by that.
+    parent = _payload(
+        "lapack",
+        conda_forge_yml={"build_platform": {"linux_riscv64": "linux_64"}},
+    )
+    migrator = LinuxRISCV64(graph=_graph(parent), effective_graph=_graph(parent))
+
+    assert not migrator.predecessors_not_yet_built(_payload("gsl"))
+
+
+def test_predecessor_migrated_via_provider_counts_as_built():
+    parent = _payload(
+        "lapack",
+        conda_forge_yml={"provider": {"linux_riscv64": "default"}},
+    )
+    migrator = LinuxRISCV64(graph=_graph(parent), effective_graph=_graph(parent))
+
+    assert not migrator.predecessors_not_yet_built(_payload("gsl"))
+
+
+def test_unmigrated_predecessor_still_blocks():
+    # the parent has neither the arch configured nor a PR record -> still blocked
+    migrator = LinuxRISCV64(
+        graph=_graph(_payload("lapack")),
+        effective_graph=_graph(_payload("lapack")),
+    )
+
+    assert migrator.predecessors_not_yet_built(_payload("gsl"))
+
+
+def test_predecessor_with_open_pr_still_blocks():
+    parent = _payload("lapack")
+    migrator = LinuxRISCV64(graph=_graph(parent), effective_graph=_graph(parent))
+    muid = frozen_to_json_friendly(migrator.migrator_uid(parent))
+    parent["pr_info"]["PRed"] = [{"data": muid["data"], "PR": {"state": "open"}}]
+
+    assert migrator.predecessors_not_yet_built(_payload("gsl"))
+
+
+def test_predecessor_with_merged_pr_counts_as_built():
+    parent = _payload("lapack")
+    migrator = LinuxRISCV64(graph=_graph(parent), effective_graph=_graph(parent))
+    muid = frozen_to_json_friendly(migrator.migrator_uid(parent))
+    parent["pr_info"]["PRed"] = [{"data": muid["data"], "PR": {"state": "closed"}}]
+
+    assert not migrator.predecessors_not_yet_built(_payload("gsl"))

--- a/tests/test_graph_migrator_predecessors.py
+++ b/tests/test_graph_migrator_predecessors.py
@@ -115,11 +115,22 @@ def test_arch_rebuild_predecessor_migrated_counts_as_built():
 
 
 def test_no_arches_is_not_configured():
-    # an empty `arches` means there is nothing to detect, not that the feedstock is
-    # configured for everything -- the latter would mark every predecessor as built
+    # `all` over an empty iterable is true, so the natural spelling would mark every
+    # predecessor as built; defaulting to "done" is the dangerous way to be wrong
     parent = _payload(
         "lapack",
         conda_forge_yml={"build_platform": {"linux_riscv64": "linux_64"}},
     )
 
     assert not _arches_are_configured(parent, {})
+
+
+def test_null_conda_forge_yml_sections_do_not_raise():
+    # the bot writes null rather than omitting a section, so a plain `.get(..., {})`
+    # chain would raise AttributeError on the None
+    parent = _payload(
+        "lapack",
+        conda_forge_yml={"provider": None, "build_platform": None},
+    )
+
+    assert not _arches_are_configured(parent, {"linux_riscv64": "linux_64"})

--- a/tests/test_graph_migrator_predecessors.py
+++ b/tests/test_graph_migrator_predecessors.py
@@ -1,6 +1,10 @@
 import networkx as nx
 
-from conda_forge_tick.migrators.arch import ArchRebuild, LinuxRISCV64
+from conda_forge_tick.migrators.arch import (
+    ArchRebuild,
+    LinuxRISCV64,
+    _arches_are_configured,
+)
 from conda_forge_tick.migrators.core import GraphMigrator
 from conda_forge_tick.utils import frozen_to_json_friendly
 
@@ -108,3 +112,14 @@ def test_arch_rebuild_predecessor_migrated_counts_as_built():
 
     assert migrator.predecessor_already_migrated(parent)
     assert not migrator.predecessors_not_yet_built(_payload("gsl"))
+
+
+def test_no_arches_is_not_configured():
+    # an empty `arches` means there is nothing to detect, not that the feedstock is
+    # configured for everything -- the latter would mark every predecessor as built
+    parent = _payload(
+        "lapack",
+        conda_forge_yml={"build_platform": {"linux_riscv64": "linux_64"}},
+    )
+
+    assert not _arches_are_configured(parent, {})

--- a/tests/test_graph_migrator_predecessors.py
+++ b/tests/test_graph_migrator_predecessors.py
@@ -1,6 +1,7 @@
 import networkx as nx
 
-from conda_forge_tick.migrators.arch import LinuxRISCV64
+from conda_forge_tick.migrators.arch import ArchRebuild, LinuxRISCV64
+from conda_forge_tick.migrators.core import GraphMigrator
 from conda_forge_tick.utils import frozen_to_json_friendly
 
 
@@ -71,4 +72,39 @@ def test_predecessor_with_merged_pr_counts_as_built():
     muid = frozen_to_json_friendly(migrator.migrator_uid(parent))
     parent["pr_info"]["PRed"] = [{"data": muid["data"], "PR": {"state": "closed"}}]
 
+    assert not migrator.predecessors_not_yet_built(_payload("gsl"))
+
+
+class _PlainGraphMigrator(GraphMigrator):
+    """A graph migrator with no feedstock-visible notion of "already migrated"."""
+
+    migrator_version = 0
+
+
+def test_default_hook_does_not_treat_config_as_migrated():
+    # non-arch migrators keep the old behaviour: only a PRed record counts, so an
+    # arch key in conda-forge.yml means nothing to them
+    parent = _payload(
+        "lapack",
+        conda_forge_yml={"build_platform": {"linux_riscv64": "linux_64"}},
+    )
+    migrator = _PlainGraphMigrator(
+        name="test migration",
+        graph=_graph(parent),
+        effective_graph=_graph(parent),
+    )
+
+    assert not migrator.predecessor_already_migrated(parent)
+    assert migrator.predecessors_not_yet_built(_payload("gsl"))
+
+
+def test_arch_rebuild_predecessor_migrated_counts_as_built():
+    # the same fix applies to the aarch64 migrator
+    parent = _payload(
+        "lapack",
+        conda_forge_yml={"provider": {"linux_aarch64": "default"}},
+    )
+    migrator = ArchRebuild(graph=_graph(parent), effective_graph=_graph(parent))
+
+    assert migrator.predecessor_already_migrated(parent)
     assert not migrator.predecessors_not_yet_built(_payload("gsl"))


### PR DESCRIPTION
## Problem

`GraphMigrator.predecessors_not_yet_built` decides whether a parent is built by looking only at `pr_info.PRed`. A feedstock migrated by hand or by a rerender never gets a `PRed` entry, and nothing can add one after the fact — so such a parent blocks all of its children permanently.

This is live on the riscv64 migration: `blas` and `lapack` both have `build_platform: {linux_riscv64: linux_64}` and ship `linux-riscv64` artifacts, but have no `LinuxRISCV64` record in `PRed`. That stalls `gsl` → `r-base` → the 29 `r-*` packages, i.e. 30 of the 43 feedstocks currently shown as "awaiting parents" on the [riscv64 status page](https://conda-forge.org/status/migration/?name=supportlinuxriscv64platform).

The bot already knows those parents are migrated — `filter_node_migrated` reads it off `conda-forge.yml`, which is why the status page lists them as done. The two checks just disagreed about what "built" means.

## Change

- New `GraphMigrator.predecessor_already_migrated()` hook, defaulting to `False`, consulted before the `PRed` lookup. Non-arch migrators are unaffected.
- `ArchRebuild` and `_CrossCompileRebuild` override it with the existing `conda-forge.yml` provider/`build_platform` check, extracted to a shared `_arches_are_configured()` helper (it was duplicated verbatim in both classes).

The hook deliberately ignores `PRed` records rather than reusing `filter_node_migrated`, which also returns true merely because a record exists — reusing it would let children race ahead of a parent whose PR is still open, for every graph migrator. `test_predecessor_with_open_pr_still_blocks` covers that.

Fixes aarch64, osx-arm64 and win-arm64 the same way.

## Tests

`tests/test_graph_migrator_predecessors.py` — five cases on a `lapack → gsl` graph: migrated via `build_platform`, migrated via `provider`, unmigrated parent still blocks, open PR still blocks, merged PR counts as built.


cc @conda-forge/help-riscv64