### PR TITLE
Report feedstock-detected migrations as done on the status page

### DIFF
--- a/conda_forge_tick/status_report.py
+++ b/conda_forge_tick/status_report.py
@@ -247,8 +247,13 @@ def graph_migrator_status(
         # No PR was ever issued but the migration was performed.
         # This is only the case when the migration was done manually
         # before the bot could issue any PR.
-        manually_done = pr_json is None and frozen_to_json_friendly(nuid)["data"] in (
-            z["data"] for z in all_pr_jsons
+        manually_done = pr_json is None and (
+            frozen_to_json_friendly(nuid)["data"] in (z["data"] for z in all_pr_jsons)
+            # the migrator may also be able to tell from the feedstock itself, e.g.
+            # the arch migrators read the arches off conda-forge.yml. Without this,
+            # a feedstock migrated by hand or by a rerender has no PRed record to
+            # match and falls through to the "awaiting-parents" catch-all below.
+            or migrator.filter_node_migrated(attrs)
         )
 
         if pr_json is not None and "PR" in pr_json:

--- a/tests/test_status_report.py
+++ b/tests/test_status_report.py
@@ -1,0 +1,50 @@
+import networkx as nx
+
+from conda_forge_tick.migrators.arch import LinuxRISCV64
+from conda_forge_tick.status_report import graph_migrator_status
+
+
+def _payload(name, conda_forge_yml=None):
+    return {
+        "name": name,
+        "feedstock_name": name,
+        "archived": False,
+        "conda-forge.yml": conda_forge_yml or {},
+        "pr_info": {"PRed": []},
+    }
+
+
+def _graph(parent_payload):
+    gx = nx.DiGraph()
+    gx.add_node("lapack", payload=parent_payload)
+    gx.add_node("gsl", payload=_payload("gsl"))
+    gx.add_edge("lapack", "gsl")
+    return gx
+
+
+def test_manually_migrated_node_reports_as_done():
+    # lapack got linux_riscv64 through a rerender rather than a bot PR, so there is
+    # no PRed record to match the migrator uid against. It should still report as
+    # done rather than landing in the "awaiting-parents" catch-all.
+    gx = _graph(
+        _payload("lapack", {"build_platform": {"linux_riscv64": "linux_64"}}),
+    )
+
+    migrator = LinuxRISCV64(graph=gx, effective_graph=gx.copy())
+    out, _, _ = graph_migrator_status(migrator, gx)
+
+    assert "lapack" in out["done"]
+    assert "lapack" not in out["awaiting-parents"]
+    # ... and its child is released for a PR rather than waiting on it
+    assert "gsl" in out["awaiting-pr"]
+
+
+def test_unmigrated_node_does_not_report_as_done():
+    gx = _graph(_payload("lapack"))
+
+    migrator = LinuxRISCV64(graph=gx, effective_graph=gx.copy())
+    out, _, _ = graph_migrator_status(migrator, gx)
+
+    assert "lapack" not in out["done"]
+    assert "lapack" in out["awaiting-pr"]
+    assert "gsl" in out["awaiting-parents"]


### PR DESCRIPTION
Follow-up to #6680, reported by @h-vetinari [here](https://github.com/conda-forge/conda-forge-bot/pull/6680#issuecomment-5614711908): with #6680 merged the bot correctly opened the `gsl` PR for the riscv64 migration, but `lapack` and `blas` — both migrated by hand — still show as not done on the status page.
